### PR TITLE
Update openapi.yaml

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2601,7 +2601,7 @@ components:
             \ summary_arg\"\n"
           type: integer
           writeOnly: true
-        email_subect:
+        email_subject:
           description: "Channel: Email\nRequired.  The subject of the email.\n"
           type: string
           writeOnly: true


### PR DESCRIPTION
Fix typo 

https://github.com/OneSignal/onesignal-go-api/blob/d4f62230c7d54002d5eff1fff6e6bbf000745c3e/model_notification.go#L4191

This typo cause a request like this
```
curl --location --request POST 'https://onesignal.com/api/v1/notifications' \
--header 'Content-Type: application/json;charset=utf-8' \
--header 'Authorization: Basic API_KEY' \
--data-raw '{
    "app_id": "APP_ID", 
    "email_subect": "Welcome!",
    "email_body": "Lorem ipsum",
    "include_email_tokens": ["user@example.com"]
}'
```

Response
```
{
    "errors": [
        "Message Emails must have a subject"
    ]
}
```