### PR TITLE
Release 2.0.0 module version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information, please visit [https://onesignal.com](https://onesignal.com
 ## Installation
 
 ```shell
-go get github.com/OneSignal/onesignal-go-api
+go get github.com/OneSignal/onesignal-go-api/v2
 ```
 
 Install the following dependencies:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
-module github.com/OneSignal/onesignal-go-api
+module github.com/OneSignal/onesignal-go-api/v2
 
 go 1.13
 
-require (
-	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
-)
+require golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558


### PR DESCRIPTION
# Description
## One Line Summary
Update go.mod url to include v2

## Details
In go a major version bump we must ensure that the import path is different from other major version. The v1 version doesn't need any suffix, all following major version bump must have the major version suffix in the module name

### Motivation
required for major version bump
