### PR TITLE
fix build: use OrganizationApiKey field

### DIFF
--- a/client.go
+++ b/client.go
@@ -354,7 +354,7 @@ func (c *APIClient) prepareRequest(
 		}
 
         // AccessToken Authentication
-		if auth, ok := ctx.Value(OrganizationKey).(string); ok {
+		if auth, ok := ctx.Value(OrganizationApiKey).(string); ok {
 			localVarRequest.Header.Add("Authorization", "Key "+auth)
 		}
 


### PR DESCRIPTION
# Description
## One Line Summary
Use `OrganizationApiKey` instead of `OrganizationKey` for fixing golang build.

## Details
Currently the client isn't compiled because `OrganizationKey` is unknown variable 

### Motivation
Build client, now the build is broken.

### Scope
Client build

### OPTIONAL - Other

# Testing

## Manual testing
Run `go build .` in the client to make sure that the client can be built


# Checklist
## Overview
   - [x ] I have filled out all **REQUIRED** sections above
   - [ x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.