### PR TITLE
feat: add v5.4.0 package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-- API version: 5.3.0
-- Package version: 5.3.0
+- API version: 5.4.0
+- Package version: 5.4.0
 
 ## Installation
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,7 +8,7 @@ info:
     customer engagement strategies. Learn more at onesignal.com
   termsOfService: https://onesignal.com/tos
   title: OneSignal
-  version: 5.3.0
+  version: 5.4.0
 servers:
 - url: https://api.onesignal.com
 paths:
@@ -3849,8 +3849,96 @@ components:
           ro: ro
           nl: nl
           tr: tr
+        subtitle:
+          de: de
+          hi: hi
+          fi: fi
+          ru: ru
+          pt: pt
+          bg: bg
+          lt: lt
+          hr: hr
+          lv: lv
+          fr: fr
+          hu: hu
+          bs: bs
+          zh-Hans: zh-Hans
+          zh-Hant: zh-Hant
+          ka: ka
+          uk: uk
+          sk: sk
+          id: id
+          ca: ca
+          sr: sr
+          sv: sv
+          ko: ko
+          ms: ms
+          el: el
+          en: en
+          it: it
+          zh: zh
+          es: es
+          et: et
+          cs: cs
+          ar: ar
+          pa: pa
+          vi: vi
+          nb: nb
+          th: th
+          ja: ja
+          fa: fa
+          pl: pl
+          da: da
+          he: he
+          ro: ro
+          nl: nl
+          tr: tr
         name: name
         isEmail: true
+        headings:
+          de: de
+          hi: hi
+          fi: fi
+          ru: ru
+          pt: pt
+          bg: bg
+          lt: lt
+          hr: hr
+          lv: lv
+          fr: fr
+          hu: hu
+          bs: bs
+          zh-Hans: zh-Hans
+          zh-Hant: zh-Hant
+          ka: ka
+          uk: uk
+          sk: sk
+          id: id
+          ca: ca
+          sr: sr
+          sv: sv
+          ko: ko
+          ms: ms
+          el: el
+          en: en
+          it: it
+          zh: zh
+          es: es
+          et: et
+          cs: cs
+          ar: ar
+          pa: pa
+          vi: vi
+          nb: nb
+          th: th
+          ja: ja
+          fa: fa
+          pl: pl
+          da: da
+          he: he
+          ro: ro
+          nl: nl
+          tr: tr
         dynamic_content: dynamic_content
         app_id: app_id
         email_subject: email_subject
@@ -3862,6 +3950,10 @@ components:
           description: Name of the template.
           type: string
         contents:
+          $ref: '#/components/schemas/LanguageStringMap'
+        headings:
+          $ref: '#/components/schemas/LanguageStringMap'
+        subtitle:
           $ref: '#/components/schemas/LanguageStringMap'
         isEmail:
           description: Set true for an Email template.
@@ -3934,8 +4026,96 @@ components:
           ro: ro
           nl: nl
           tr: tr
+        subtitle:
+          de: de
+          hi: hi
+          fi: fi
+          ru: ru
+          pt: pt
+          bg: bg
+          lt: lt
+          hr: hr
+          lv: lv
+          fr: fr
+          hu: hu
+          bs: bs
+          zh-Hans: zh-Hans
+          zh-Hant: zh-Hant
+          ka: ka
+          uk: uk
+          sk: sk
+          id: id
+          ca: ca
+          sr: sr
+          sv: sv
+          ko: ko
+          ms: ms
+          el: el
+          en: en
+          it: it
+          zh: zh
+          es: es
+          et: et
+          cs: cs
+          ar: ar
+          pa: pa
+          vi: vi
+          nb: nb
+          th: th
+          ja: ja
+          fa: fa
+          pl: pl
+          da: da
+          he: he
+          ro: ro
+          nl: nl
+          tr: tr
         name: name
         isEmail: true
+        headings:
+          de: de
+          hi: hi
+          fi: fi
+          ru: ru
+          pt: pt
+          bg: bg
+          lt: lt
+          hr: hr
+          lv: lv
+          fr: fr
+          hu: hu
+          bs: bs
+          zh-Hans: zh-Hans
+          zh-Hant: zh-Hant
+          ka: ka
+          uk: uk
+          sk: sk
+          id: id
+          ca: ca
+          sr: sr
+          sv: sv
+          ko: ko
+          ms: ms
+          el: el
+          en: en
+          it: it
+          zh: zh
+          es: es
+          et: et
+          cs: cs
+          ar: ar
+          pa: pa
+          vi: vi
+          nb: nb
+          th: th
+          ja: ja
+          fa: fa
+          pl: pl
+          da: da
+          he: he
+          ro: ro
+          nl: nl
+          tr: tr
         dynamic_content: dynamic_content
         email_subject: email_subject
       properties:
@@ -3943,6 +4123,10 @@ components:
           description: Updated name of the template.
           type: string
         contents:
+          $ref: '#/components/schemas/LanguageStringMap'
+        headings:
+          $ref: '#/components/schemas/LanguageStringMap'
+        subtitle:
           $ref: '#/components/schemas/LanguageStringMap'
         isEmail:
           description: Set true for an Email template.
@@ -4643,6 +4827,7 @@ components:
           description: "Channel: Push Notifications\nPlatform: Android\nThe Android\
             \ Oreo Notification Category to send the notification under. See the Category\
             \ documentation on creating one and getting it's id.\n"
+          nullable: true
           type: string
           writeOnly: true
         huawei_channel_id:
@@ -4656,6 +4841,7 @@ components:
           description: "Channel: Push Notifications\nPlatform: Android\nUse this if\
             \ you have client side Android Oreo Channels you have already defined\
             \ in your app with code.\n"
+          nullable: true
           type: string
           writeOnly: true
         huawei_existing_channel_id:

--- a/api_default.go
+++ b/api_default.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -42,7 +42,7 @@ var (
 	xmlCheck  = regexp.MustCompile(`(?i:(?:application|text)/xml)`)
 )
 
-// APIClient manages communication with the OneSignal API v5.3.0
+// APIClient manages communication with the OneSignal API v5.4.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration
@@ -324,7 +324,7 @@ func (c *APIClient) prepareRequest(
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 
     // Add the SDK version to OS-Usage header for telemetry
-    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.3.0")
+    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.4.0")
 
 	if ctx != nil {
 		// add context to the request

--- a/configuration.go
+++ b/configuration.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -105,7 +105,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/5.3.0/go",
+		UserAgent:        "OpenAPI-Generator/5.4.0/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -55,9 +55,9 @@ Name | Type | Description | Notes
 **Buttons** | Pointer to [**[]Button**](Button.md) | Channel: Push Notifications Platform: iOS 8.0+, Android 4.1+, and derivatives like Amazon Buttons to add to the notification. Icon only works for Android. Buttons show in reverse order of array position i.e. Last item in array shows as first button on device. Example: [{\&quot;id\&quot;: \&quot;id2\&quot;, \&quot;text\&quot;: \&quot;second button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_share\&quot;}, {\&quot;id\&quot;: \&quot;id1\&quot;, \&quot;text\&quot;: \&quot;first button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_send\&quot;}]  | [optional] 
 **WebButtons** | Pointer to [**[]WebButton**](WebButton.md) | Channel: Push Notifications Platform: Chrome 48+ Add action buttons to the notification. The id field is required. Example: [{\&quot;id\&quot;: \&quot;like-button\&quot;, \&quot;text\&quot;: \&quot;Like\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/N8SN8ZS.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}, {\&quot;id\&quot;: \&quot;read-more-button\&quot;, \&quot;text\&quot;: \&quot;Read more\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/MIxJp1L.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}]  | [optional] 
 **IosCategory** | Pointer to **NullableString** | Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category.  | [optional] 
-**AndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
+**AndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
 **HuaweiChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
-**ExistingAndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
+**ExistingAndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **HuaweiExistingChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **AndroidBackgroundLayout** | Pointer to [**BasicNotificationAllOfAndroidBackgroundLayout**](BasicNotificationAllOfAndroidBackgroundLayout.md) |  | [optional] 
 **SmallIcon** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Icon shown in the status bar and on the top left of the notification. If not set a bell icon will be used or ic_stat_onesignal_default if you have set this resource name. See: How to create small icons  | [optional] 
@@ -1783,6 +1783,16 @@ SetAndroidChannelId sets AndroidChannelId field to given value.
 
 HasAndroidChannelId returns a boolean if a field has been set.
 
+### SetAndroidChannelIdNil
+
+`func (o *BasicNotification) SetAndroidChannelIdNil(b bool)`
+
+ SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+
+### UnsetAndroidChannelId
+`func (o *BasicNotification) UnsetAndroidChannelId()`
+
+UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
 ### GetHuaweiChannelId
 
 `func (o *BasicNotification) GetHuaweiChannelId() string`
@@ -1843,6 +1853,16 @@ SetExistingAndroidChannelId sets ExistingAndroidChannelId field to given value.
 
 HasExistingAndroidChannelId returns a boolean if a field has been set.
 
+### SetExistingAndroidChannelIdNil
+
+`func (o *BasicNotification) SetExistingAndroidChannelIdNil(b bool)`
+
+ SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+
+### UnsetExistingAndroidChannelId
+`func (o *BasicNotification) UnsetExistingAndroidChannelId()`
+
+UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
 ### GetHuaweiExistingChannelId
 
 `func (o *BasicNotification) GetHuaweiExistingChannelId() string`

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -42,9 +42,9 @@ Name | Type | Description | Notes
 **Buttons** | Pointer to [**[]Button**](Button.md) | Channel: Push Notifications Platform: iOS 8.0+, Android 4.1+, and derivatives like Amazon Buttons to add to the notification. Icon only works for Android. Buttons show in reverse order of array position i.e. Last item in array shows as first button on device. Example: [{\&quot;id\&quot;: \&quot;id2\&quot;, \&quot;text\&quot;: \&quot;second button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_share\&quot;}, {\&quot;id\&quot;: \&quot;id1\&quot;, \&quot;text\&quot;: \&quot;first button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_send\&quot;}]  | [optional] 
 **WebButtons** | Pointer to [**[]WebButton**](WebButton.md) | Channel: Push Notifications Platform: Chrome 48+ Add action buttons to the notification. The id field is required. Example: [{\&quot;id\&quot;: \&quot;like-button\&quot;, \&quot;text\&quot;: \&quot;Like\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/N8SN8ZS.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}, {\&quot;id\&quot;: \&quot;read-more-button\&quot;, \&quot;text\&quot;: \&quot;Read more\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/MIxJp1L.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}]  | [optional] 
 **IosCategory** | Pointer to **NullableString** | Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category.  | [optional] 
-**AndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
+**AndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
 **HuaweiChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
-**ExistingAndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
+**ExistingAndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **HuaweiExistingChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **AndroidBackgroundLayout** | Pointer to [**BasicNotificationAllOfAndroidBackgroundLayout**](BasicNotificationAllOfAndroidBackgroundLayout.md) |  | [optional] 
 **SmallIcon** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Icon shown in the status bar and on the top left of the notification. If not set a bell icon will be used or ic_stat_onesignal_default if you have set this resource name. See: How to create small icons  | [optional] 
@@ -1430,6 +1430,16 @@ SetAndroidChannelId sets AndroidChannelId field to given value.
 
 HasAndroidChannelId returns a boolean if a field has been set.
 
+### SetAndroidChannelIdNil
+
+`func (o *BasicNotificationAllOf) SetAndroidChannelIdNil(b bool)`
+
+ SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+
+### UnsetAndroidChannelId
+`func (o *BasicNotificationAllOf) UnsetAndroidChannelId()`
+
+UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
 ### GetHuaweiChannelId
 
 `func (o *BasicNotificationAllOf) GetHuaweiChannelId() string`
@@ -1490,6 +1500,16 @@ SetExistingAndroidChannelId sets ExistingAndroidChannelId field to given value.
 
 HasExistingAndroidChannelId returns a boolean if a field has been set.
 
+### SetExistingAndroidChannelIdNil
+
+`func (o *BasicNotificationAllOf) SetExistingAndroidChannelIdNil(b bool)`
+
+ SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+
+### UnsetExistingAndroidChannelId
+`func (o *BasicNotificationAllOf) UnsetExistingAndroidChannelId()`
+
+UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
 ### GetHuaweiExistingChannelId
 
 `func (o *BasicNotificationAllOf) GetHuaweiExistingChannelId() string`

--- a/docs/CreateTemplateRequest.md
+++ b/docs/CreateTemplateRequest.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **AppId** | **string** | Your OneSignal App ID in UUID v4 format. | 
 **Name** | **string** | Name of the template. | 
 **Contents** | [**LanguageStringMap**](LanguageStringMap.md) |  | 
+**Headings** | Pointer to [**LanguageStringMap**](LanguageStringMap.md) |  | [optional] 
+**Subtitle** | Pointer to [**LanguageStringMap**](LanguageStringMap.md) |  | [optional] 
 **IsEmail** | Pointer to **bool** | Set true for an Email template. | [optional] 
 **EmailSubject** | Pointer to **NullableString** | Subject of the email. | [optional] 
 **EmailBody** | Pointer to **NullableString** | Body of the email (HTML supported). | [optional] 
@@ -91,6 +93,56 @@ and a boolean to check if the value has been set.
 
 SetContents sets Contents field to given value.
 
+
+### GetHeadings
+
+`func (o *CreateTemplateRequest) GetHeadings() LanguageStringMap`
+
+GetHeadings returns the Headings field if non-nil, zero value otherwise.
+
+### GetHeadingsOk
+
+`func (o *CreateTemplateRequest) GetHeadingsOk() (*LanguageStringMap, bool)`
+
+GetHeadingsOk returns a tuple with the Headings field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetHeadings
+
+`func (o *CreateTemplateRequest) SetHeadings(v LanguageStringMap)`
+
+SetHeadings sets Headings field to given value.
+
+### HasHeadings
+
+`func (o *CreateTemplateRequest) HasHeadings() bool`
+
+HasHeadings returns a boolean if a field has been set.
+
+### GetSubtitle
+
+`func (o *CreateTemplateRequest) GetSubtitle() LanguageStringMap`
+
+GetSubtitle returns the Subtitle field if non-nil, zero value otherwise.
+
+### GetSubtitleOk
+
+`func (o *CreateTemplateRequest) GetSubtitleOk() (*LanguageStringMap, bool)`
+
+GetSubtitleOk returns a tuple with the Subtitle field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSubtitle
+
+`func (o *CreateTemplateRequest) SetSubtitle(v LanguageStringMap)`
+
+SetSubtitle sets Subtitle field to given value.
+
+### HasSubtitle
+
+`func (o *CreateTemplateRequest) HasSubtitle() bool`
+
+HasSubtitle returns a boolean if a field has been set.
 
 ### GetIsEmail
 

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -55,9 +55,9 @@ Name | Type | Description | Notes
 **Buttons** | Pointer to [**[]Button**](Button.md) | Channel: Push Notifications Platform: iOS 8.0+, Android 4.1+, and derivatives like Amazon Buttons to add to the notification. Icon only works for Android. Buttons show in reverse order of array position i.e. Last item in array shows as first button on device. Example: [{\&quot;id\&quot;: \&quot;id2\&quot;, \&quot;text\&quot;: \&quot;second button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_share\&quot;}, {\&quot;id\&quot;: \&quot;id1\&quot;, \&quot;text\&quot;: \&quot;first button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_send\&quot;}]  | [optional] 
 **WebButtons** | Pointer to [**[]WebButton**](WebButton.md) | Channel: Push Notifications Platform: Chrome 48+ Add action buttons to the notification. The id field is required. Example: [{\&quot;id\&quot;: \&quot;like-button\&quot;, \&quot;text\&quot;: \&quot;Like\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/N8SN8ZS.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}, {\&quot;id\&quot;: \&quot;read-more-button\&quot;, \&quot;text\&quot;: \&quot;Read more\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/MIxJp1L.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}]  | [optional] 
 **IosCategory** | Pointer to **NullableString** | Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category.  | [optional] 
-**AndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
+**AndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
 **HuaweiChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
-**ExistingAndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
+**ExistingAndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **HuaweiExistingChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **AndroidBackgroundLayout** | Pointer to [**BasicNotificationAllOfAndroidBackgroundLayout**](BasicNotificationAllOfAndroidBackgroundLayout.md) |  | [optional] 
 **SmallIcon** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Icon shown in the status bar and on the top left of the notification. If not set a bell icon will be used or ic_stat_onesignal_default if you have set this resource name. See: How to create small icons  | [optional] 
@@ -1784,6 +1784,16 @@ SetAndroidChannelId sets AndroidChannelId field to given value.
 
 HasAndroidChannelId returns a boolean if a field has been set.
 
+### SetAndroidChannelIdNil
+
+`func (o *Notification) SetAndroidChannelIdNil(b bool)`
+
+ SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+
+### UnsetAndroidChannelId
+`func (o *Notification) UnsetAndroidChannelId()`
+
+UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
 ### GetHuaweiChannelId
 
 `func (o *Notification) GetHuaweiChannelId() string`
@@ -1844,6 +1854,16 @@ SetExistingAndroidChannelId sets ExistingAndroidChannelId field to given value.
 
 HasExistingAndroidChannelId returns a boolean if a field has been set.
 
+### SetExistingAndroidChannelIdNil
+
+`func (o *Notification) SetExistingAndroidChannelIdNil(b bool)`
+
+ SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+
+### UnsetExistingAndroidChannelId
+`func (o *Notification) UnsetExistingAndroidChannelId()`
+
+UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
 ### GetHuaweiExistingChannelId
 
 `func (o *Notification) GetHuaweiExistingChannelId() string`

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -55,9 +55,9 @@ Name | Type | Description | Notes
 **Buttons** | Pointer to [**[]Button**](Button.md) | Channel: Push Notifications Platform: iOS 8.0+, Android 4.1+, and derivatives like Amazon Buttons to add to the notification. Icon only works for Android. Buttons show in reverse order of array position i.e. Last item in array shows as first button on device. Example: [{\&quot;id\&quot;: \&quot;id2\&quot;, \&quot;text\&quot;: \&quot;second button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_share\&quot;}, {\&quot;id\&quot;: \&quot;id1\&quot;, \&quot;text\&quot;: \&quot;first button\&quot;, \&quot;icon\&quot;: \&quot;ic_menu_send\&quot;}]  | [optional] 
 **WebButtons** | Pointer to [**[]WebButton**](WebButton.md) | Channel: Push Notifications Platform: Chrome 48+ Add action buttons to the notification. The id field is required. Example: [{\&quot;id\&quot;: \&quot;like-button\&quot;, \&quot;text\&quot;: \&quot;Like\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/N8SN8ZS.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}, {\&quot;id\&quot;: \&quot;read-more-button\&quot;, \&quot;text\&quot;: \&quot;Read more\&quot;, \&quot;icon\&quot;: \&quot;http://i.imgur.com/MIxJp1L.png\&quot;, \&quot;url\&quot;: \&quot;https://yoursite.com\&quot;}]  | [optional] 
 **IosCategory** | Pointer to **NullableString** | Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category.  | [optional] 
-**AndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
+**AndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
 **HuaweiChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it&#39;s id.  | [optional] 
-**ExistingAndroidChannelId** | Pointer to **string** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
+**ExistingAndroidChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **HuaweiExistingChannelId** | Pointer to **NullableString** | Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code.  | [optional] 
 **AndroidBackgroundLayout** | Pointer to [**BasicNotificationAllOfAndroidBackgroundLayout**](BasicNotificationAllOfAndroidBackgroundLayout.md) |  | [optional] 
 **SmallIcon** | Pointer to **NullableString** | Channel: Push Notifications Platform: Android Icon shown in the status bar and on the top left of the notification. If not set a bell icon will be used or ic_stat_onesignal_default if you have set this resource name. See: How to create small icons  | [optional] 
@@ -1795,6 +1795,16 @@ SetAndroidChannelId sets AndroidChannelId field to given value.
 
 HasAndroidChannelId returns a boolean if a field has been set.
 
+### SetAndroidChannelIdNil
+
+`func (o *NotificationWithMeta) SetAndroidChannelIdNil(b bool)`
+
+ SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+
+### UnsetAndroidChannelId
+`func (o *NotificationWithMeta) UnsetAndroidChannelId()`
+
+UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
 ### GetHuaweiChannelId
 
 `func (o *NotificationWithMeta) GetHuaweiChannelId() string`
@@ -1855,6 +1865,16 @@ SetExistingAndroidChannelId sets ExistingAndroidChannelId field to given value.
 
 HasExistingAndroidChannelId returns a boolean if a field has been set.
 
+### SetExistingAndroidChannelIdNil
+
+`func (o *NotificationWithMeta) SetExistingAndroidChannelIdNil(b bool)`
+
+ SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+
+### UnsetExistingAndroidChannelId
+`func (o *NotificationWithMeta) UnsetExistingAndroidChannelId()`
+
+UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
 ### GetHuaweiExistingChannelId
 
 `func (o *NotificationWithMeta) GetHuaweiExistingChannelId() string`

--- a/docs/UpdateTemplateRequest.md
+++ b/docs/UpdateTemplateRequest.md
@@ -6,6 +6,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **string** | Updated name of the template. | [optional] 
 **Contents** | Pointer to [**LanguageStringMap**](LanguageStringMap.md) |  | [optional] 
+**Headings** | Pointer to [**LanguageStringMap**](LanguageStringMap.md) |  | [optional] 
+**Subtitle** | Pointer to [**LanguageStringMap**](LanguageStringMap.md) |  | [optional] 
 **IsEmail** | Pointer to **bool** | Set true for an Email template. | [optional] 
 **EmailSubject** | Pointer to **NullableString** | Subject of the email. | [optional] 
 **EmailBody** | Pointer to **NullableString** | Body of the email (HTML supported). | [optional] 
@@ -80,6 +82,56 @@ SetContents sets Contents field to given value.
 `func (o *UpdateTemplateRequest) HasContents() bool`
 
 HasContents returns a boolean if a field has been set.
+
+### GetHeadings
+
+`func (o *UpdateTemplateRequest) GetHeadings() LanguageStringMap`
+
+GetHeadings returns the Headings field if non-nil, zero value otherwise.
+
+### GetHeadingsOk
+
+`func (o *UpdateTemplateRequest) GetHeadingsOk() (*LanguageStringMap, bool)`
+
+GetHeadingsOk returns a tuple with the Headings field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetHeadings
+
+`func (o *UpdateTemplateRequest) SetHeadings(v LanguageStringMap)`
+
+SetHeadings sets Headings field to given value.
+
+### HasHeadings
+
+`func (o *UpdateTemplateRequest) HasHeadings() bool`
+
+HasHeadings returns a boolean if a field has been set.
+
+### GetSubtitle
+
+`func (o *UpdateTemplateRequest) GetSubtitle() LanguageStringMap`
+
+GetSubtitle returns the Subtitle field if non-nil, zero value otherwise.
+
+### GetSubtitleOk
+
+`func (o *UpdateTemplateRequest) GetSubtitleOk() (*LanguageStringMap, bool)`
+
+GetSubtitleOk returns a tuple with the Subtitle field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSubtitle
+
+`func (o *UpdateTemplateRequest) SetSubtitle(v LanguageStringMap)`
+
+SetSubtitle sets Subtitle field to given value.
+
+### HasSubtitle
+
+`func (o *UpdateTemplateRequest) HasSubtitle() bool`
+
+HasSubtitle returns a boolean if a field has been set.
 
 ### GetIsEmail
 

--- a/model_api_key_token.go
+++ b/model_api_key_token.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_api_key_tokens_list_response.go
+++ b/model_api_key_tokens_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_app.go
+++ b/model_app.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -114,11 +114,11 @@ type BasicNotification struct {
 	// Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category. 
 	IosCategory NullableString `json:"ios_category,omitempty"`
 	// Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
-	AndroidChannelId *string `json:"android_channel_id,omitempty"`
+	AndroidChannelId NullableString `json:"android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
 	HuaweiChannelId NullableString `json:"huawei_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
-	ExistingAndroidChannelId *string `json:"existing_android_channel_id,omitempty"`
+	ExistingAndroidChannelId NullableString `json:"existing_android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
 	HuaweiExistingChannelId NullableString `json:"huawei_existing_channel_id,omitempty"`
 	AndroidBackgroundLayout *BasicNotificationAllOfAndroidBackgroundLayout `json:"android_background_layout,omitempty"`
@@ -2183,36 +2183,46 @@ func (o *BasicNotification) UnsetIosCategory() {
 	o.IosCategory.Unset()
 }
 
-// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise.
+// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotification) GetAndroidChannelId() string {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil || o.AndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.AndroidChannelId
+	return *o.AndroidChannelId.Get()
 }
 
 // GetAndroidChannelIdOk returns a tuple with the AndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotification) GetAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.AndroidChannelId, true
+	return o.AndroidChannelId.Get(), o.AndroidChannelId.IsSet()
 }
 
 // HasAndroidChannelId returns a boolean if a field has been set.
 func (o *BasicNotification) HasAndroidChannelId() bool {
-	if o != nil && o.AndroidChannelId != nil {
+	if o != nil && o.AndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetAndroidChannelId gets a reference to the given string and assigns it to the AndroidChannelId field.
+// SetAndroidChannelId gets a reference to the given NullableString and assigns it to the AndroidChannelId field.
 func (o *BasicNotification) SetAndroidChannelId(v string) {
-	o.AndroidChannelId = &v
+	o.AndroidChannelId.Set(&v)
+}
+// SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+func (o *BasicNotification) SetAndroidChannelIdNil() {
+	o.AndroidChannelId.Set(nil)
+}
+
+// UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
+func (o *BasicNotification) UnsetAndroidChannelId() {
+	o.AndroidChannelId.Unset()
 }
 
 // GetHuaweiChannelId returns the HuaweiChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -2257,36 +2267,46 @@ func (o *BasicNotification) UnsetHuaweiChannelId() {
 	o.HuaweiChannelId.Unset()
 }
 
-// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise.
+// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotification) GetExistingAndroidChannelId() string {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil || o.ExistingAndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.ExistingAndroidChannelId
+	return *o.ExistingAndroidChannelId.Get()
 }
 
 // GetExistingAndroidChannelIdOk returns a tuple with the ExistingAndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotification) GetExistingAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.ExistingAndroidChannelId, true
+	return o.ExistingAndroidChannelId.Get(), o.ExistingAndroidChannelId.IsSet()
 }
 
 // HasExistingAndroidChannelId returns a boolean if a field has been set.
 func (o *BasicNotification) HasExistingAndroidChannelId() bool {
-	if o != nil && o.ExistingAndroidChannelId != nil {
+	if o != nil && o.ExistingAndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetExistingAndroidChannelId gets a reference to the given string and assigns it to the ExistingAndroidChannelId field.
+// SetExistingAndroidChannelId gets a reference to the given NullableString and assigns it to the ExistingAndroidChannelId field.
 func (o *BasicNotification) SetExistingAndroidChannelId(v string) {
-	o.ExistingAndroidChannelId = &v
+	o.ExistingAndroidChannelId.Set(&v)
+}
+// SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+func (o *BasicNotification) SetExistingAndroidChannelIdNil() {
+	o.ExistingAndroidChannelId.Set(nil)
+}
+
+// UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
+func (o *BasicNotification) UnsetExistingAndroidChannelId() {
+	o.ExistingAndroidChannelId.Unset()
 }
 
 // GetHuaweiExistingChannelId returns the HuaweiExistingChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -4849,14 +4869,14 @@ func (o BasicNotification) MarshalJSON() ([]byte, error) {
 	if o.IosCategory.IsSet() {
 		toSerialize["ios_category"] = o.IosCategory.Get()
 	}
-	if o.AndroidChannelId != nil {
-		toSerialize["android_channel_id"] = o.AndroidChannelId
+	if o.AndroidChannelId.IsSet() {
+		toSerialize["android_channel_id"] = o.AndroidChannelId.Get()
 	}
 	if o.HuaweiChannelId.IsSet() {
 		toSerialize["huawei_channel_id"] = o.HuaweiChannelId.Get()
 	}
-	if o.ExistingAndroidChannelId != nil {
-		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId
+	if o.ExistingAndroidChannelId.IsSet() {
+		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId.Get()
 	}
 	if o.HuaweiExistingChannelId.IsSet() {
 		toSerialize["huawei_existing_channel_id"] = o.HuaweiExistingChannelId.Get()

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -89,11 +89,11 @@ type BasicNotificationAllOf struct {
 	// Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category. 
 	IosCategory NullableString `json:"ios_category,omitempty"`
 	// Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
-	AndroidChannelId *string `json:"android_channel_id,omitempty"`
+	AndroidChannelId NullableString `json:"android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
 	HuaweiChannelId NullableString `json:"huawei_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
-	ExistingAndroidChannelId *string `json:"existing_android_channel_id,omitempty"`
+	ExistingAndroidChannelId NullableString `json:"existing_android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
 	HuaweiExistingChannelId NullableString `json:"huawei_existing_channel_id,omitempty"`
 	AndroidBackgroundLayout *BasicNotificationAllOfAndroidBackgroundLayout `json:"android_background_layout,omitempty"`
@@ -1747,36 +1747,46 @@ func (o *BasicNotificationAllOf) UnsetIosCategory() {
 	o.IosCategory.Unset()
 }
 
-// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise.
+// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotificationAllOf) GetAndroidChannelId() string {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil || o.AndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.AndroidChannelId
+	return *o.AndroidChannelId.Get()
 }
 
 // GetAndroidChannelIdOk returns a tuple with the AndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotificationAllOf) GetAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.AndroidChannelId, true
+	return o.AndroidChannelId.Get(), o.AndroidChannelId.IsSet()
 }
 
 // HasAndroidChannelId returns a boolean if a field has been set.
 func (o *BasicNotificationAllOf) HasAndroidChannelId() bool {
-	if o != nil && o.AndroidChannelId != nil {
+	if o != nil && o.AndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetAndroidChannelId gets a reference to the given string and assigns it to the AndroidChannelId field.
+// SetAndroidChannelId gets a reference to the given NullableString and assigns it to the AndroidChannelId field.
 func (o *BasicNotificationAllOf) SetAndroidChannelId(v string) {
-	o.AndroidChannelId = &v
+	o.AndroidChannelId.Set(&v)
+}
+// SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+func (o *BasicNotificationAllOf) SetAndroidChannelIdNil() {
+	o.AndroidChannelId.Set(nil)
+}
+
+// UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
+func (o *BasicNotificationAllOf) UnsetAndroidChannelId() {
+	o.AndroidChannelId.Unset()
 }
 
 // GetHuaweiChannelId returns the HuaweiChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -1821,36 +1831,46 @@ func (o *BasicNotificationAllOf) UnsetHuaweiChannelId() {
 	o.HuaweiChannelId.Unset()
 }
 
-// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise.
+// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotificationAllOf) GetExistingAndroidChannelId() string {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil || o.ExistingAndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.ExistingAndroidChannelId
+	return *o.ExistingAndroidChannelId.Get()
 }
 
 // GetExistingAndroidChannelIdOk returns a tuple with the ExistingAndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotificationAllOf) GetExistingAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.ExistingAndroidChannelId, true
+	return o.ExistingAndroidChannelId.Get(), o.ExistingAndroidChannelId.IsSet()
 }
 
 // HasExistingAndroidChannelId returns a boolean if a field has been set.
 func (o *BasicNotificationAllOf) HasExistingAndroidChannelId() bool {
-	if o != nil && o.ExistingAndroidChannelId != nil {
+	if o != nil && o.ExistingAndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetExistingAndroidChannelId gets a reference to the given string and assigns it to the ExistingAndroidChannelId field.
+// SetExistingAndroidChannelId gets a reference to the given NullableString and assigns it to the ExistingAndroidChannelId field.
 func (o *BasicNotificationAllOf) SetExistingAndroidChannelId(v string) {
-	o.ExistingAndroidChannelId = &v
+	o.ExistingAndroidChannelId.Set(&v)
+}
+// SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+func (o *BasicNotificationAllOf) SetExistingAndroidChannelIdNil() {
+	o.ExistingAndroidChannelId.Set(nil)
+}
+
+// UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
+func (o *BasicNotificationAllOf) UnsetExistingAndroidChannelId() {
+	o.ExistingAndroidChannelId.Unset()
 }
 
 // GetHuaweiExistingChannelId returns the HuaweiExistingChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -4374,14 +4394,14 @@ func (o BasicNotificationAllOf) MarshalJSON() ([]byte, error) {
 	if o.IosCategory.IsSet() {
 		toSerialize["ios_category"] = o.IosCategory.Get()
 	}
-	if o.AndroidChannelId != nil {
-		toSerialize["android_channel_id"] = o.AndroidChannelId
+	if o.AndroidChannelId.IsSet() {
+		toSerialize["android_channel_id"] = o.AndroidChannelId.Get()
 	}
 	if o.HuaweiChannelId.IsSet() {
 		toSerialize["huawei_channel_id"] = o.HuaweiChannelId.Get()
 	}
-	if o.ExistingAndroidChannelId != nil {
-		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId
+	if o.ExistingAndroidChannelId.IsSet() {
+		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId.Get()
 	}
 	if o.HuaweiExistingChannelId.IsSet() {
 		toSerialize["huawei_existing_channel_id"] = o.HuaweiExistingChannelId.Get()

--- a/model_basic_notification_all_of_android_background_layout.go
+++ b/model_basic_notification_all_of_android_background_layout.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_button.go
+++ b/model_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_copy_template_request.go
+++ b/model_copy_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_request.go
+++ b/model_create_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_response.go
+++ b/model_create_api_key_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_notification_success_response.go
+++ b/model_create_notification_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_conflict_response.go
+++ b/model_create_segment_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_success_response.go
+++ b/model_create_segment_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_template_request.go
+++ b/model_create_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -22,6 +22,8 @@ type CreateTemplateRequest struct {
 	// Name of the template.
 	Name string `json:"name"`
 	Contents LanguageStringMap `json:"contents"`
+	Headings *LanguageStringMap `json:"headings,omitempty"`
+	Subtitle *LanguageStringMap `json:"subtitle,omitempty"`
 	// Set true for an Email template.
 	IsEmail *bool `json:"isEmail,omitempty"`
 	// Subject of the email.
@@ -127,6 +129,70 @@ func (o *CreateTemplateRequest) GetContentsOk() (*LanguageStringMap, bool) {
 // SetContents sets field value
 func (o *CreateTemplateRequest) SetContents(v LanguageStringMap) {
 	o.Contents = v
+}
+
+// GetHeadings returns the Headings field value if set, zero value otherwise.
+func (o *CreateTemplateRequest) GetHeadings() LanguageStringMap {
+	if o == nil || o.Headings == nil {
+		var ret LanguageStringMap
+		return ret
+	}
+	return *o.Headings
+}
+
+// GetHeadingsOk returns a tuple with the Headings field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateTemplateRequest) GetHeadingsOk() (*LanguageStringMap, bool) {
+	if o == nil || o.Headings == nil {
+		return nil, false
+	}
+	return o.Headings, true
+}
+
+// HasHeadings returns a boolean if a field has been set.
+func (o *CreateTemplateRequest) HasHeadings() bool {
+	if o != nil && o.Headings != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHeadings gets a reference to the given LanguageStringMap and assigns it to the Headings field.
+func (o *CreateTemplateRequest) SetHeadings(v LanguageStringMap) {
+	o.Headings = &v
+}
+
+// GetSubtitle returns the Subtitle field value if set, zero value otherwise.
+func (o *CreateTemplateRequest) GetSubtitle() LanguageStringMap {
+	if o == nil || o.Subtitle == nil {
+		var ret LanguageStringMap
+		return ret
+	}
+	return *o.Subtitle
+}
+
+// GetSubtitleOk returns a tuple with the Subtitle field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateTemplateRequest) GetSubtitleOk() (*LanguageStringMap, bool) {
+	if o == nil || o.Subtitle == nil {
+		return nil, false
+	}
+	return o.Subtitle, true
+}
+
+// HasSubtitle returns a boolean if a field has been set.
+func (o *CreateTemplateRequest) HasSubtitle() bool {
+	if o != nil && o.Subtitle != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubtitle gets a reference to the given LanguageStringMap and assigns it to the Subtitle field.
+func (o *CreateTemplateRequest) SetSubtitle(v LanguageStringMap) {
+	o.Subtitle = &v
 }
 
 // GetIsEmail returns the IsEmail field value if set, zero value otherwise.
@@ -330,6 +396,12 @@ func (o CreateTemplateRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["contents"] = o.Contents
 	}
+	if o.Headings != nil {
+		toSerialize["headings"] = o.Headings
+	}
+	if o.Subtitle != nil {
+		toSerialize["subtitle"] = o.Subtitle
+	}
 	if o.IsEmail != nil {
 		toSerialize["isEmail"] = o.IsEmail
 	}
@@ -366,6 +438,8 @@ func (o *CreateTemplateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "app_id")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "contents")
+		delete(additionalProperties, "headings")
+		delete(additionalProperties, "subtitle")
 		delete(additionalProperties, "isEmail")
 		delete(additionalProperties, "email_subject")
 		delete(additionalProperties, "email_body")

--- a/model_create_user_conflict_response.go
+++ b/model_create_user_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_inner.go
+++ b/model_create_user_conflict_response_errors_inner.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_items_meta.go
+++ b/model_create_user_conflict_response_errors_items_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_event.go
+++ b/model_custom_event.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_events_request.go
+++ b/model_custom_events_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_delivery_data.go
+++ b/model_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_events_success_response.go
+++ b/model_export_events_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_request_body.go
+++ b/model_export_subscriptions_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_success_response.go
+++ b/model_export_subscriptions_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter.go
+++ b/model_filter.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter_expression.go
+++ b/model_filter_expression.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_error.go
+++ b/model_generic_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_success_bool_response.go
+++ b/model_generic_success_bool_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_notification_history_request_body.go
+++ b/model_get_notification_history_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_segments_success_response.go
+++ b/model_get_segments_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_language_string_map.go
+++ b/model_language_string_map.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification.go
+++ b/model_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -115,11 +115,11 @@ type Notification struct {
 	// Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category. 
 	IosCategory NullableString `json:"ios_category,omitempty"`
 	// Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
-	AndroidChannelId *string `json:"android_channel_id,omitempty"`
+	AndroidChannelId NullableString `json:"android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
 	HuaweiChannelId NullableString `json:"huawei_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
-	ExistingAndroidChannelId *string `json:"existing_android_channel_id,omitempty"`
+	ExistingAndroidChannelId NullableString `json:"existing_android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
 	HuaweiExistingChannelId NullableString `json:"huawei_existing_channel_id,omitempty"`
 	AndroidBackgroundLayout *BasicNotificationAllOfAndroidBackgroundLayout `json:"android_background_layout,omitempty"`
@@ -2186,36 +2186,46 @@ func (o *Notification) UnsetIosCategory() {
 	o.IosCategory.Unset()
 }
 
-// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise.
+// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Notification) GetAndroidChannelId() string {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil || o.AndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.AndroidChannelId
+	return *o.AndroidChannelId.Get()
 }
 
 // GetAndroidChannelIdOk returns a tuple with the AndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Notification) GetAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.AndroidChannelId, true
+	return o.AndroidChannelId.Get(), o.AndroidChannelId.IsSet()
 }
 
 // HasAndroidChannelId returns a boolean if a field has been set.
 func (o *Notification) HasAndroidChannelId() bool {
-	if o != nil && o.AndroidChannelId != nil {
+	if o != nil && o.AndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetAndroidChannelId gets a reference to the given string and assigns it to the AndroidChannelId field.
+// SetAndroidChannelId gets a reference to the given NullableString and assigns it to the AndroidChannelId field.
 func (o *Notification) SetAndroidChannelId(v string) {
-	o.AndroidChannelId = &v
+	o.AndroidChannelId.Set(&v)
+}
+// SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+func (o *Notification) SetAndroidChannelIdNil() {
+	o.AndroidChannelId.Set(nil)
+}
+
+// UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
+func (o *Notification) UnsetAndroidChannelId() {
+	o.AndroidChannelId.Unset()
 }
 
 // GetHuaweiChannelId returns the HuaweiChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -2260,36 +2270,46 @@ func (o *Notification) UnsetHuaweiChannelId() {
 	o.HuaweiChannelId.Unset()
 }
 
-// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise.
+// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Notification) GetExistingAndroidChannelId() string {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil || o.ExistingAndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.ExistingAndroidChannelId
+	return *o.ExistingAndroidChannelId.Get()
 }
 
 // GetExistingAndroidChannelIdOk returns a tuple with the ExistingAndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Notification) GetExistingAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.ExistingAndroidChannelId, true
+	return o.ExistingAndroidChannelId.Get(), o.ExistingAndroidChannelId.IsSet()
 }
 
 // HasExistingAndroidChannelId returns a boolean if a field has been set.
 func (o *Notification) HasExistingAndroidChannelId() bool {
-	if o != nil && o.ExistingAndroidChannelId != nil {
+	if o != nil && o.ExistingAndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetExistingAndroidChannelId gets a reference to the given string and assigns it to the ExistingAndroidChannelId field.
+// SetExistingAndroidChannelId gets a reference to the given NullableString and assigns it to the ExistingAndroidChannelId field.
 func (o *Notification) SetExistingAndroidChannelId(v string) {
-	o.ExistingAndroidChannelId = &v
+	o.ExistingAndroidChannelId.Set(&v)
+}
+// SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+func (o *Notification) SetExistingAndroidChannelIdNil() {
+	o.ExistingAndroidChannelId.Set(nil)
+}
+
+// UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
+func (o *Notification) UnsetExistingAndroidChannelId() {
+	o.ExistingAndroidChannelId.Unset()
 }
 
 // GetHuaweiExistingChannelId returns the HuaweiExistingChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -4894,14 +4914,14 @@ func (o Notification) MarshalJSON() ([]byte, error) {
 	if o.IosCategory.IsSet() {
 		toSerialize["ios_category"] = o.IosCategory.Get()
 	}
-	if o.AndroidChannelId != nil {
-		toSerialize["android_channel_id"] = o.AndroidChannelId
+	if o.AndroidChannelId.IsSet() {
+		toSerialize["android_channel_id"] = o.AndroidChannelId.Get()
 	}
 	if o.HuaweiChannelId.IsSet() {
 		toSerialize["huawei_channel_id"] = o.HuaweiChannelId.Get()
 	}
-	if o.ExistingAndroidChannelId != nil {
-		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId
+	if o.ExistingAndroidChannelId.IsSet() {
+		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId.Get()
 	}
 	if o.HuaweiExistingChannelId.IsSet() {
 		toSerialize["huawei_existing_channel_id"] = o.HuaweiExistingChannelId.Get()

--- a/model_notification_all_of.go
+++ b/model_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_history_success_response.go
+++ b/model_notification_history_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_slice.go
+++ b/model_notification_slice.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_target.go
+++ b/model_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -114,11 +114,11 @@ type NotificationWithMeta struct {
 	// Channel: Push Notifications Platform: iOS Category APS payload, use with registerUserNotificationSettings:categories in your Objective-C / Swift code. Example: calendar category which contains actions like accept and decline iOS 10+ This will trigger your UNNotificationContentExtension whose ID matches this category. 
 	IosCategory NullableString `json:"ios_category,omitempty"`
 	// Channel: Push Notifications Platform: Android The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
-	AndroidChannelId *string `json:"android_channel_id,omitempty"`
+	AndroidChannelId NullableString `json:"android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei The Android Oreo Notification Category to send the notification under. See the Category documentation on creating one and getting it's id. 
 	HuaweiChannelId NullableString `json:"huawei_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Android Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
-	ExistingAndroidChannelId *string `json:"existing_android_channel_id,omitempty"`
+	ExistingAndroidChannelId NullableString `json:"existing_android_channel_id,omitempty"`
 	// Channel: Push Notifications Platform: Huawei Use this if you have client side Android Oreo Channels you have already defined in your app with code. 
 	HuaweiExistingChannelId NullableString `json:"huawei_existing_channel_id,omitempty"`
 	AndroidBackgroundLayout *BasicNotificationAllOfAndroidBackgroundLayout `json:"android_background_layout,omitempty"`
@@ -2205,36 +2205,46 @@ func (o *NotificationWithMeta) UnsetIosCategory() {
 	o.IosCategory.Unset()
 }
 
-// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise.
+// GetAndroidChannelId returns the AndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NotificationWithMeta) GetAndroidChannelId() string {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil || o.AndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.AndroidChannelId
+	return *o.AndroidChannelId.Get()
 }
 
 // GetAndroidChannelIdOk returns a tuple with the AndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NotificationWithMeta) GetAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.AndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.AndroidChannelId, true
+	return o.AndroidChannelId.Get(), o.AndroidChannelId.IsSet()
 }
 
 // HasAndroidChannelId returns a boolean if a field has been set.
 func (o *NotificationWithMeta) HasAndroidChannelId() bool {
-	if o != nil && o.AndroidChannelId != nil {
+	if o != nil && o.AndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetAndroidChannelId gets a reference to the given string and assigns it to the AndroidChannelId field.
+// SetAndroidChannelId gets a reference to the given NullableString and assigns it to the AndroidChannelId field.
 func (o *NotificationWithMeta) SetAndroidChannelId(v string) {
-	o.AndroidChannelId = &v
+	o.AndroidChannelId.Set(&v)
+}
+// SetAndroidChannelIdNil sets the value for AndroidChannelId to be an explicit nil
+func (o *NotificationWithMeta) SetAndroidChannelIdNil() {
+	o.AndroidChannelId.Set(nil)
+}
+
+// UnsetAndroidChannelId ensures that no value is present for AndroidChannelId, not even an explicit nil
+func (o *NotificationWithMeta) UnsetAndroidChannelId() {
+	o.AndroidChannelId.Unset()
 }
 
 // GetHuaweiChannelId returns the HuaweiChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -2279,36 +2289,46 @@ func (o *NotificationWithMeta) UnsetHuaweiChannelId() {
 	o.HuaweiChannelId.Unset()
 }
 
-// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise.
+// GetExistingAndroidChannelId returns the ExistingAndroidChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NotificationWithMeta) GetExistingAndroidChannelId() string {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil || o.ExistingAndroidChannelId.Get() == nil {
 		var ret string
 		return ret
 	}
-	return *o.ExistingAndroidChannelId
+	return *o.ExistingAndroidChannelId.Get()
 }
 
 // GetExistingAndroidChannelIdOk returns a tuple with the ExistingAndroidChannelId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NotificationWithMeta) GetExistingAndroidChannelIdOk() (*string, bool) {
-	if o == nil || o.ExistingAndroidChannelId == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.ExistingAndroidChannelId, true
+	return o.ExistingAndroidChannelId.Get(), o.ExistingAndroidChannelId.IsSet()
 }
 
 // HasExistingAndroidChannelId returns a boolean if a field has been set.
 func (o *NotificationWithMeta) HasExistingAndroidChannelId() bool {
-	if o != nil && o.ExistingAndroidChannelId != nil {
+	if o != nil && o.ExistingAndroidChannelId.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetExistingAndroidChannelId gets a reference to the given string and assigns it to the ExistingAndroidChannelId field.
+// SetExistingAndroidChannelId gets a reference to the given NullableString and assigns it to the ExistingAndroidChannelId field.
 func (o *NotificationWithMeta) SetExistingAndroidChannelId(v string) {
-	o.ExistingAndroidChannelId = &v
+	o.ExistingAndroidChannelId.Set(&v)
+}
+// SetExistingAndroidChannelIdNil sets the value for ExistingAndroidChannelId to be an explicit nil
+func (o *NotificationWithMeta) SetExistingAndroidChannelIdNil() {
+	o.ExistingAndroidChannelId.Set(nil)
+}
+
+// UnsetExistingAndroidChannelId ensures that no value is present for ExistingAndroidChannelId, not even an explicit nil
+func (o *NotificationWithMeta) UnsetExistingAndroidChannelId() {
+	o.ExistingAndroidChannelId.Unset()
 }
 
 // GetHuaweiExistingChannelId returns the HuaweiExistingChannelId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -5285,14 +5305,14 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	if o.IosCategory.IsSet() {
 		toSerialize["ios_category"] = o.IosCategory.Get()
 	}
-	if o.AndroidChannelId != nil {
-		toSerialize["android_channel_id"] = o.AndroidChannelId
+	if o.AndroidChannelId.IsSet() {
+		toSerialize["android_channel_id"] = o.AndroidChannelId.Get()
 	}
 	if o.HuaweiChannelId.IsSet() {
 		toSerialize["huawei_channel_id"] = o.HuaweiChannelId.Get()
 	}
-	if o.ExistingAndroidChannelId != nil {
-		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId
+	if o.ExistingAndroidChannelId.IsSet() {
+		toSerialize["existing_android_channel_id"] = o.ExistingAndroidChannelId.Get()
 	}
 	if o.HuaweiExistingChannelId.IsSet() {
 		toSerialize["huawei_existing_channel_id"] = o.HuaweiExistingChannelId.Get()

--- a/model_notification_with_meta_all_of.go
+++ b/model_notification_with_meta_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_operator.go
+++ b/model_operator.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcome_data.go
+++ b/model_outcome_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcomes_data.go
+++ b/model_outcomes_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data.go
+++ b/model_platform_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_email_all_of.go
+++ b/model_platform_delivery_data_email_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_sms_all_of.go
+++ b/model_platform_delivery_data_sms_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_body.go
+++ b/model_properties_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_deltas.go
+++ b/model_properties_deltas.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_object.go
+++ b/model_properties_object.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_purchase.go
+++ b/model_purchase.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_rate_limit_error.go
+++ b/model_rate_limit_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment.go
+++ b/model_segment.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_data.go
+++ b/model_segment_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_notification_target.go
+++ b/model_segment_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_request.go
+++ b/model_start_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_success_response.go
+++ b/model_start_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription.go
+++ b/model_subscription.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_body.go
+++ b/model_subscription_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_notification_target.go
+++ b/model_subscription_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_template_resource.go
+++ b/model_template_resource.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_templates_list_response.go
+++ b/model_templates_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_transfer_subscription_request_body.go
+++ b/model_transfer_subscription_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_api_key_request.go
+++ b/model_update_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_request.go
+++ b/model_update_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_success_response.go
+++ b/model_update_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_template_request.go
+++ b/model_update_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 
@@ -20,6 +20,8 @@ type UpdateTemplateRequest struct {
 	// Updated name of the template.
 	Name *string `json:"name,omitempty"`
 	Contents *LanguageStringMap `json:"contents,omitempty"`
+	Headings *LanguageStringMap `json:"headings,omitempty"`
+	Subtitle *LanguageStringMap `json:"subtitle,omitempty"`
 	// Set true for an Email template.
 	IsEmail *bool `json:"isEmail,omitempty"`
 	// Subject of the email.
@@ -114,6 +116,70 @@ func (o *UpdateTemplateRequest) HasContents() bool {
 // SetContents gets a reference to the given LanguageStringMap and assigns it to the Contents field.
 func (o *UpdateTemplateRequest) SetContents(v LanguageStringMap) {
 	o.Contents = &v
+}
+
+// GetHeadings returns the Headings field value if set, zero value otherwise.
+func (o *UpdateTemplateRequest) GetHeadings() LanguageStringMap {
+	if o == nil || o.Headings == nil {
+		var ret LanguageStringMap
+		return ret
+	}
+	return *o.Headings
+}
+
+// GetHeadingsOk returns a tuple with the Headings field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateTemplateRequest) GetHeadingsOk() (*LanguageStringMap, bool) {
+	if o == nil || o.Headings == nil {
+		return nil, false
+	}
+	return o.Headings, true
+}
+
+// HasHeadings returns a boolean if a field has been set.
+func (o *UpdateTemplateRequest) HasHeadings() bool {
+	if o != nil && o.Headings != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHeadings gets a reference to the given LanguageStringMap and assigns it to the Headings field.
+func (o *UpdateTemplateRequest) SetHeadings(v LanguageStringMap) {
+	o.Headings = &v
+}
+
+// GetSubtitle returns the Subtitle field value if set, zero value otherwise.
+func (o *UpdateTemplateRequest) GetSubtitle() LanguageStringMap {
+	if o == nil || o.Subtitle == nil {
+		var ret LanguageStringMap
+		return ret
+	}
+	return *o.Subtitle
+}
+
+// GetSubtitleOk returns a tuple with the Subtitle field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateTemplateRequest) GetSubtitleOk() (*LanguageStringMap, bool) {
+	if o == nil || o.Subtitle == nil {
+		return nil, false
+	}
+	return o.Subtitle, true
+}
+
+// HasSubtitle returns a boolean if a field has been set.
+func (o *UpdateTemplateRequest) HasSubtitle() bool {
+	if o != nil && o.Subtitle != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubtitle gets a reference to the given LanguageStringMap and assigns it to the Subtitle field.
+func (o *UpdateTemplateRequest) SetSubtitle(v LanguageStringMap) {
+	o.Subtitle = &v
 }
 
 // GetIsEmail returns the IsEmail field value if set, zero value otherwise.
@@ -314,6 +380,12 @@ func (o UpdateTemplateRequest) MarshalJSON() ([]byte, error) {
 	if o.Contents != nil {
 		toSerialize["contents"] = o.Contents
 	}
+	if o.Headings != nil {
+		toSerialize["headings"] = o.Headings
+	}
+	if o.Subtitle != nil {
+		toSerialize["subtitle"] = o.Subtitle
+	}
 	if o.IsEmail != nil {
 		toSerialize["isEmail"] = o.IsEmail
 	}
@@ -349,6 +421,8 @@ func (o *UpdateTemplateRequest) UnmarshalJSON(bytes []byte) (err error) {
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "contents")
+		delete(additionalProperties, "headings")
+		delete(additionalProperties, "subtitle")
 		delete(additionalProperties, "isEmail")
 		delete(additionalProperties, "email_subject")
 		delete(additionalProperties, "email_body")

--- a/model_update_user_request.go
+++ b/model_update_user_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user.go
+++ b/model_user.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user_identity_body.go
+++ b/model_user_identity_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_web_button.go
+++ b/model_web_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/response.go
+++ b/response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.3.0
+API version: 5.4.0
 Contact: devrel@onesignal.com
 */
 


### PR DESCRIPTION
## Summary

Release `v5.4.0` of the OneSignal Go API client library.

Generated from upstream [OneSignal/api-client-libraries#351](https://github.com/OneSignal/api-client-libraries/pull/351).

## Changes

### Spec

- **feat(api)**: add `headings` and `subtitle` to template push request body
- **fix(spec)**: mark `android_channel_id` and `existing_android_channel_id` as nullable

### Documentation

- **feat**: README overhauled to match the server SDK reference format
- **fix**: convert relative documentation links to absolute GitHub URLs so they render correctly on pkg.go.dev
- **fix**: update `DefaultApi.md` cross-file links

## Post-merge

Merging this PR triggers semantic-release, which tags `v5.4.0` and makes it available via `go get` from [pkg.go.dev](https://pkg.go.dev/github.com/OneSignal/onesignal-go-api).