### PR TITLE
docs: add v5.4.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -121,6 +121,7 @@ paths:
       security:
       - rest_api_key: []
       summary: Create notification
+      x-onesignal-flat-notification-example: true
   /notifications/{notification_id}:
     delete:
       description: Used to stop a scheduled or currently outgoing notification

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -614,20 +614,23 @@ import (
 )
 
 func main() {
-    notification := *onesignal.NewNotification("AppId_example") // Notification | 
-
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
 
-    restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY") // App REST API key required for most endpoints
+    restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY")
 
-    resp, r, err := apiClient.DefaultApi.CreateNotification(restAuth).Notification(notification).Execute()
+    notification := onesignal.NewNotification("YOUR_APP_ID")
+    contents := onesignal.NewLanguageStringMap()
+    contents.SetEn("Hello from OneSignal!")
+    notification.SetContents(*contents)
+    notification.SetIncludeAliases(map[string][]string{"external_id": {"YOUR_USER_EXTERNAL_ID"}})
+    notification.SetTargetChannel("push")
 
+    resp, r, err := apiClient.DefaultApi.CreateNotification(restAuth).Notification(*notification).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
-    // response from `CreateNotification`: CreateNotificationSuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateNotification`: %v\n", resp)
 }
 ```


### PR DESCRIPTION
## Updates
- docs: add flat create-notification doc examples via vendor extension

---
_Generated from [OneSignal/api-client-libraries@bc71af6...35a92b9](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...35a92b9872393d79d8270897b2e134f2b42562b0)._