### PR TITLE
feat: add v5.4.0 package updates

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           # SDK Server Project
           project-url: https://github.com/orgs/OneSignal/projects/11
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3926,6 +3926,12 @@ components:
           tr: tr
         name: name
         isEmail: true
+        email_bcc:
+        - email_bcc
+        - email_bcc
+        - email_bcc
+        - email_bcc
+        - email_bcc
         headings:
           de: de
           hi: hi
@@ -3997,6 +4003,14 @@ components:
           description: Body of the email (HTML supported).
           nullable: true
           type: string
+        email_bcc:
+          description: BCC recipients for the email template. Maximum 5 addresses.
+            Only supported when the email service provider is OneSignal Email.
+          items:
+            type: string
+          maxItems: 5
+          nullable: true
+          type: array
         isSMS:
           description: Set true for an SMS template.
           type: boolean
@@ -4103,6 +4117,12 @@ components:
           tr: tr
         name: name
         isEmail: true
+        email_bcc:
+        - email_bcc
+        - email_bcc
+        - email_bcc
+        - email_bcc
+        - email_bcc
         headings:
           de: de
           hi: hi
@@ -4170,6 +4190,14 @@ components:
           description: Body of the email (HTML supported).
           nullable: true
           type: string
+        email_bcc:
+          description: BCC recipients for the email template. Maximum 5 addresses.
+            Only supported when the email service provider is OneSignal Email.
+          items:
+            type: string
+          maxItems: 5
+          nullable: true
+          type: array
         isSMS:
           description: Set true for an SMS template.
           type: boolean
@@ -5302,6 +5330,15 @@ components:
             \ of unsubscribed emails to be cleared."
           type: boolean
           writeOnly: true
+        email_bcc:
+          description: "Channel: Email\nBCC recipients for the email. Maximum 5 addresses.\
+            \ Only supported when the email service provider is OneSignal Email.\n"
+          items:
+            type: string
+          maxItems: 5
+          nullable: true
+          type: array
+          writeOnly: true
         sms_from:
           description: "Channel: SMS\nPhone Number used to send SMS. Should be a registered\
             \ Twilio phone number in E.164 format.\n"
@@ -5445,6 +5482,16 @@ components:
           description: Indicates whether the notification was canceled before it could
             be sent.
           type: boolean
+        email_bcc:
+          description: BCC recipients that were set on this email notification.
+          items:
+            type: string
+          nullable: true
+          type: array
+        bcc_sent:
+          description: Number of BCC copies successfully sent for this notification.
+          nullable: true
+          type: integer
       type: object
     PlatformDeliveryData_sms_allOf:
       properties:

--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -109,6 +109,7 @@ Name | Type | Description | Notes
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -3578,6 +3579,41 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### GetEmailBcc
+
+`func (o *BasicNotification) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *BasicNotification) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *BasicNotification) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *BasicNotification) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *BasicNotification) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *BasicNotification) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *BasicNotification) GetSmsFrom() string`

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -96,6 +96,7 @@ Name | Type | Description | Notes
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -3225,6 +3226,41 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### GetEmailBcc
+
+`func (o *BasicNotificationAllOf) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *BasicNotificationAllOf) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *BasicNotificationAllOf) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *BasicNotificationAllOf) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *BasicNotificationAllOf) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *BasicNotificationAllOf) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *BasicNotificationAllOf) GetSmsFrom() string`

--- a/docs/CreateTemplateRequest.md
+++ b/docs/CreateTemplateRequest.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **IsEmail** | Pointer to **bool** | Set true for an Email template. | [optional] 
 **EmailSubject** | Pointer to **NullableString** | Subject of the email. | [optional] 
 **EmailBody** | Pointer to **NullableString** | Body of the email (HTML supported). | [optional] 
+**EmailBcc** | Pointer to **[]string** | BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. | [optional] 
 **IsSMS** | Pointer to **bool** | Set true for an SMS template. | [optional] 
 **DynamicContent** | Pointer to **NullableString** | JSON string for dynamic content personalization. | [optional] 
 
@@ -239,6 +240,41 @@ HasEmailBody returns a boolean if a field has been set.
 `func (o *CreateTemplateRequest) UnsetEmailBody()`
 
 UnsetEmailBody ensures that no value is present for EmailBody, not even an explicit nil
+### GetEmailBcc
+
+`func (o *CreateTemplateRequest) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *CreateTemplateRequest) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *CreateTemplateRequest) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *CreateTemplateRequest) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *CreateTemplateRequest) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *CreateTemplateRequest) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetIsSMS
 
 `func (o *CreateTemplateRequest) GetIsSMS() bool`

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -109,6 +109,7 @@ Name | Type | Description | Notes
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -3579,6 +3580,41 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### GetEmailBcc
+
+`func (o *Notification) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *Notification) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *Notification) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *Notification) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *Notification) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *Notification) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *Notification) GetSmsFrom() string`

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -109,6 +109,7 @@ Name | Type | Description | Notes
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**EmailBcc** | Pointer to **[]string** | BCC recipients that were set on this email notification. | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -130,6 +131,7 @@ Name | Type | Description | Notes
 **CompletedAt** | Pointer to **NullableInt64** | Unix timestamp indicating when notification delivery completed. The delivery duration from start to finish can be calculated with completed_at - send_after. | [optional] 
 **PlatformDeliveryStats** | Pointer to [**PlatformDeliveryData**](PlatformDeliveryData.md) |  | [optional] 
 **Canceled** | Pointer to **bool** | Indicates whether the notification was canceled before it could be sent. | [optional] 
+**BccSent** | Pointer to **NullableInt32** | Number of BCC copies successfully sent for this notification. | [optional] 
 
 ## Methods
 
@@ -3590,6 +3592,41 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### GetEmailBcc
+
+`func (o *NotificationWithMeta) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *NotificationWithMeta) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *NotificationWithMeta) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *NotificationWithMeta) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *NotificationWithMeta) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *NotificationWithMeta) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *NotificationWithMeta) GetSmsFrom() string`
@@ -4235,6 +4272,41 @@ SetCanceled sets Canceled field to given value.
 
 HasCanceled returns a boolean if a field has been set.
 
+### GetBccSent
+
+`func (o *NotificationWithMeta) GetBccSent() int32`
+
+GetBccSent returns the BccSent field if non-nil, zero value otherwise.
+
+### GetBccSentOk
+
+`func (o *NotificationWithMeta) GetBccSentOk() (*int32, bool)`
+
+GetBccSentOk returns a tuple with the BccSent field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBccSent
+
+`func (o *NotificationWithMeta) SetBccSent(v int32)`
+
+SetBccSent sets BccSent field to given value.
+
+### HasBccSent
+
+`func (o *NotificationWithMeta) HasBccSent() bool`
+
+HasBccSent returns a boolean if a field has been set.
+
+### SetBccSentNil
+
+`func (o *NotificationWithMeta) SetBccSentNil(b bool)`
+
+ SetBccSentNil sets the value for BccSent to be an explicit nil
+
+### UnsetBccSent
+`func (o *NotificationWithMeta) UnsetBccSent()`
+
+UnsetBccSent ensures that no value is present for BccSent, not even an explicit nil
 
 [[Back to API list]](https://github.com/OneSignal/onesignal-go-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-go-api)
 

--- a/docs/NotificationWithMetaAllOf.md
+++ b/docs/NotificationWithMetaAllOf.md
@@ -16,6 +16,8 @@ Name | Type | Description | Notes
 **Received** | Pointer to **NullableInt32** | Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0. | [optional] 
 **ThrottleRatePerMinute** | Pointer to **NullableInt32** | number of push notifications sent per minute. Paid Feature Only. If throttling is not enabled for the app or the notification, and for free accounts, null is returned. Refer to Throttling for more details. | [optional] 
 **Canceled** | Pointer to **bool** | Indicates whether the notification was canceled before it could be sent. | [optional] 
+**EmailBcc** | Pointer to **[]string** | BCC recipients that were set on this email notification. | [optional] 
+**BccSent** | Pointer to **NullableInt32** | Number of BCC copies successfully sent for this notification. | [optional] 
 
 ## Methods
 
@@ -376,6 +378,76 @@ SetCanceled sets Canceled field to given value.
 
 HasCanceled returns a boolean if a field has been set.
 
+### GetEmailBcc
+
+`func (o *NotificationWithMetaAllOf) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *NotificationWithMetaAllOf) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *NotificationWithMetaAllOf) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *NotificationWithMetaAllOf) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *NotificationWithMetaAllOf) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *NotificationWithMetaAllOf) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
+### GetBccSent
+
+`func (o *NotificationWithMetaAllOf) GetBccSent() int32`
+
+GetBccSent returns the BccSent field if non-nil, zero value otherwise.
+
+### GetBccSentOk
+
+`func (o *NotificationWithMetaAllOf) GetBccSentOk() (*int32, bool)`
+
+GetBccSentOk returns a tuple with the BccSent field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBccSent
+
+`func (o *NotificationWithMetaAllOf) SetBccSent(v int32)`
+
+SetBccSent sets BccSent field to given value.
+
+### HasBccSent
+
+`func (o *NotificationWithMetaAllOf) HasBccSent() bool`
+
+HasBccSent returns a boolean if a field has been set.
+
+### SetBccSentNil
+
+`func (o *NotificationWithMetaAllOf) SetBccSentNil(b bool)`
+
+ SetBccSentNil sets the value for BccSent to be an explicit nil
+
+### UnsetBccSent
+`func (o *NotificationWithMetaAllOf) UnsetBccSent()`
+
+UnsetBccSent ensures that no value is present for BccSent, not even an explicit nil
 
 [[Back to API list]](https://github.com/OneSignal/onesignal-go-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-go-api)
 

--- a/docs/UpdateTemplateRequest.md
+++ b/docs/UpdateTemplateRequest.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **IsEmail** | Pointer to **bool** | Set true for an Email template. | [optional] 
 **EmailSubject** | Pointer to **NullableString** | Subject of the email. | [optional] 
 **EmailBody** | Pointer to **NullableString** | Body of the email (HTML supported). | [optional] 
+**EmailBcc** | Pointer to **[]string** | BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. | [optional] 
 **IsSMS** | Pointer to **bool** | Set true for an SMS template. | [optional] 
 **DynamicContent** | Pointer to **NullableString** | JSON string for dynamic content personalization. | [optional] 
 
@@ -228,6 +229,41 @@ HasEmailBody returns a boolean if a field has been set.
 `func (o *UpdateTemplateRequest) UnsetEmailBody()`
 
 UnsetEmailBody ensures that no value is present for EmailBody, not even an explicit nil
+### GetEmailBcc
+
+`func (o *UpdateTemplateRequest) GetEmailBcc() []string`
+
+GetEmailBcc returns the EmailBcc field if non-nil, zero value otherwise.
+
+### GetEmailBccOk
+
+`func (o *UpdateTemplateRequest) GetEmailBccOk() (*[]string, bool)`
+
+GetEmailBccOk returns a tuple with the EmailBcc field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailBcc
+
+`func (o *UpdateTemplateRequest) SetEmailBcc(v []string)`
+
+SetEmailBcc sets EmailBcc field to given value.
+
+### HasEmailBcc
+
+`func (o *UpdateTemplateRequest) HasEmailBcc() bool`
+
+HasEmailBcc returns a boolean if a field has been set.
+
+### SetEmailBccNil
+
+`func (o *UpdateTemplateRequest) SetEmailBccNil(b bool)`
+
+ SetEmailBccNil sets the value for EmailBcc to be an explicit nil
+
+### UnsetEmailBcc
+`func (o *UpdateTemplateRequest) UnsetEmailBcc()`
+
+UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
 ### GetIsSMS
 
 `func (o *UpdateTemplateRequest) GetIsSMS() bool`

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -220,6 +220,8 @@ type BasicNotification struct {
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -4363,6 +4365,39 @@ func (o *BasicNotification) SetIncludeUnsubscribed(v bool) {
 	o.IncludeUnsubscribed = &v
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BasicNotification) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BasicNotification) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *BasicNotification) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *BasicNotification) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotification) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -5031,6 +5066,9 @@ func (o BasicNotification) MarshalJSON() ([]byte, error) {
 	if o.IncludeUnsubscribed != nil {
 		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5181,6 +5219,7 @@ func (o *BasicNotification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "email_preheader")
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -195,6 +195,8 @@ type BasicNotificationAllOf struct {
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -3927,6 +3929,39 @@ func (o *BasicNotificationAllOf) SetIncludeUnsubscribed(v bool) {
 	o.IncludeUnsubscribed = &v
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BasicNotificationAllOf) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BasicNotificationAllOf) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *BasicNotificationAllOf) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *BasicNotificationAllOf) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotificationAllOf) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -4556,6 +4591,9 @@ func (o BasicNotificationAllOf) MarshalJSON() ([]byte, error) {
 	if o.IncludeUnsubscribed != nil {
 		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -4693,6 +4731,7 @@ func (o *BasicNotificationAllOf) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "email_preheader")
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_create_template_request.go
+++ b/model_create_template_request.go
@@ -30,6 +30,8 @@ type CreateTemplateRequest struct {
 	EmailSubject NullableString `json:"email_subject,omitempty"`
 	// Body of the email (HTML supported).
 	EmailBody NullableString `json:"email_body,omitempty"`
+	// BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Set true for an SMS template.
 	IsSMS *bool `json:"isSMS,omitempty"`
 	// JSON string for dynamic content personalization.
@@ -311,6 +313,39 @@ func (o *CreateTemplateRequest) UnsetEmailBody() {
 	o.EmailBody.Unset()
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CreateTemplateRequest) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CreateTemplateRequest) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *CreateTemplateRequest) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *CreateTemplateRequest) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetIsSMS returns the IsSMS field value if set, zero value otherwise.
 func (o *CreateTemplateRequest) GetIsSMS() bool {
 	if o == nil || o.IsSMS == nil {
@@ -411,6 +446,9 @@ func (o CreateTemplateRequest) MarshalJSON() ([]byte, error) {
 	if o.EmailBody.IsSet() {
 		toSerialize["email_body"] = o.EmailBody.Get()
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.IsSMS != nil {
 		toSerialize["isSMS"] = o.IsSMS
 	}
@@ -443,6 +481,7 @@ func (o *CreateTemplateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "isEmail")
 		delete(additionalProperties, "email_subject")
 		delete(additionalProperties, "email_body")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "isSMS")
 		delete(additionalProperties, "dynamic_content")
 		o.AdditionalProperties = additionalProperties

--- a/model_notification.go
+++ b/model_notification.go
@@ -221,6 +221,8 @@ type Notification struct {
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -4366,6 +4368,39 @@ func (o *Notification) SetIncludeUnsubscribed(v bool) {
 	o.IncludeUnsubscribed = &v
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Notification) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *Notification) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *Notification) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *Notification) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Notification) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -5076,6 +5111,9 @@ func (o Notification) MarshalJSON() ([]byte, error) {
 	if o.IncludeUnsubscribed != nil {
 		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5229,6 +5267,7 @@ func (o *Notification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "email_preheader")
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -220,6 +220,8 @@ type NotificationWithMeta struct {
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	// BCC recipients that were set on this email notification.
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -259,6 +261,8 @@ type NotificationWithMeta struct {
 	PlatformDeliveryStats *PlatformDeliveryData `json:"platform_delivery_stats,omitempty"`
 	// Indicates whether the notification was canceled before it could be sent.
 	Canceled *bool `json:"canceled,omitempty"`
+	// Number of BCC copies successfully sent for this notification.
+	BccSent NullableInt32 `json:"bcc_sent,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -4385,6 +4389,39 @@ func (o *NotificationWithMeta) SetIncludeUnsubscribed(v bool) {
 	o.IncludeUnsubscribed = &v
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NotificationWithMeta) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NotificationWithMeta) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *NotificationWithMeta) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *NotificationWithMeta) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NotificationWithMeta) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -5150,6 +5187,48 @@ func (o *NotificationWithMeta) SetCanceled(v bool) {
 	o.Canceled = &v
 }
 
+// GetBccSent returns the BccSent field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NotificationWithMeta) GetBccSent() int32 {
+	if o == nil || o.BccSent.Get() == nil {
+		var ret int32
+		return ret
+	}
+	return *o.BccSent.Get()
+}
+
+// GetBccSentOk returns a tuple with the BccSent field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NotificationWithMeta) GetBccSentOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.BccSent.Get(), o.BccSent.IsSet()
+}
+
+// HasBccSent returns a boolean if a field has been set.
+func (o *NotificationWithMeta) HasBccSent() bool {
+	if o != nil && o.BccSent.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetBccSent gets a reference to the given NullableInt32 and assigns it to the BccSent field.
+func (o *NotificationWithMeta) SetBccSent(v int32) {
+	o.BccSent.Set(&v)
+}
+// SetBccSentNil sets the value for BccSent to be an explicit nil
+func (o *NotificationWithMeta) SetBccSentNil() {
+	o.BccSent.Set(nil)
+}
+
+// UnsetBccSent ensures that no value is present for BccSent, not even an explicit nil
+func (o *NotificationWithMeta) UnsetBccSent() {
+	o.BccSent.Unset()
+}
+
 func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.IncludedSegments != nil {
@@ -5467,6 +5546,9 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	if o.IncludeUnsubscribed != nil {
 		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5529,6 +5611,9 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	}
 	if o.Canceled != nil {
 		toSerialize["canceled"] = o.Canceled
+	}
+	if o.BccSent.IsSet() {
+		toSerialize["bcc_sent"] = o.BccSent.Get()
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -5653,6 +5738,7 @@ func (o *NotificationWithMeta) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "email_preheader")
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")
@@ -5674,6 +5760,7 @@ func (o *NotificationWithMeta) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "completed_at")
 		delete(additionalProperties, "platform_delivery_stats")
 		delete(additionalProperties, "canceled")
+		delete(additionalProperties, "bcc_sent")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/model_notification_with_meta_all_of.go
+++ b/model_notification_with_meta_all_of.go
@@ -40,6 +40,10 @@ type NotificationWithMetaAllOf struct {
 	ThrottleRatePerMinute NullableInt32 `json:"throttle_rate_per_minute,omitempty"`
 	// Indicates whether the notification was canceled before it could be sent.
 	Canceled *bool `json:"canceled,omitempty"`
+	// BCC recipients that were set on this email notification.
+	EmailBcc []string `json:"email_bcc,omitempty"`
+	// Number of BCC copies successfully sent for this notification.
+	BccSent NullableInt32 `json:"bcc_sent,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -486,6 +490,81 @@ func (o *NotificationWithMetaAllOf) SetCanceled(v bool) {
 	o.Canceled = &v
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NotificationWithMetaAllOf) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NotificationWithMetaAllOf) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *NotificationWithMetaAllOf) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *NotificationWithMetaAllOf) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
+// GetBccSent returns the BccSent field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NotificationWithMetaAllOf) GetBccSent() int32 {
+	if o == nil || o.BccSent.Get() == nil {
+		var ret int32
+		return ret
+	}
+	return *o.BccSent.Get()
+}
+
+// GetBccSentOk returns a tuple with the BccSent field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NotificationWithMetaAllOf) GetBccSentOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.BccSent.Get(), o.BccSent.IsSet()
+}
+
+// HasBccSent returns a boolean if a field has been set.
+func (o *NotificationWithMetaAllOf) HasBccSent() bool {
+	if o != nil && o.BccSent.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetBccSent gets a reference to the given NullableInt32 and assigns it to the BccSent field.
+func (o *NotificationWithMetaAllOf) SetBccSent(v int32) {
+	o.BccSent.Set(&v)
+}
+// SetBccSentNil sets the value for BccSent to be an explicit nil
+func (o *NotificationWithMetaAllOf) SetBccSentNil() {
+	o.BccSent.Set(nil)
+}
+
+// UnsetBccSent ensures that no value is present for BccSent, not even an explicit nil
+func (o *NotificationWithMetaAllOf) UnsetBccSent() {
+	o.BccSent.Unset()
+}
+
 func (o NotificationWithMetaAllOf) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Remaining != nil {
@@ -524,6 +603,12 @@ func (o NotificationWithMetaAllOf) MarshalJSON() ([]byte, error) {
 	if o.Canceled != nil {
 		toSerialize["canceled"] = o.Canceled
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
+	if o.BccSent.IsSet() {
+		toSerialize["bcc_sent"] = o.BccSent.Get()
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -554,6 +639,8 @@ func (o *NotificationWithMetaAllOf) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "received")
 		delete(additionalProperties, "throttle_rate_per_minute")
 		delete(additionalProperties, "canceled")
+		delete(additionalProperties, "email_bcc")
+		delete(additionalProperties, "bcc_sent")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/model_update_template_request.go
+++ b/model_update_template_request.go
@@ -28,6 +28,8 @@ type UpdateTemplateRequest struct {
 	EmailSubject NullableString `json:"email_subject,omitempty"`
 	// Body of the email (HTML supported).
 	EmailBody NullableString `json:"email_body,omitempty"`
+	// BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.
+	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Set true for an SMS template.
 	IsSMS *bool `json:"isSMS,omitempty"`
 	// JSON string for dynamic content personalization.
@@ -298,6 +300,39 @@ func (o *UpdateTemplateRequest) UnsetEmailBody() {
 	o.EmailBody.Unset()
 }
 
+// GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateTemplateRequest) GetEmailBcc() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailBcc
+}
+
+// GetEmailBccOk returns a tuple with the EmailBcc field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateTemplateRequest) GetEmailBccOk() ([]string, bool) {
+	if o == nil || o.EmailBcc == nil {
+		return nil, false
+	}
+	return o.EmailBcc, true
+}
+
+// HasEmailBcc returns a boolean if a field has been set.
+func (o *UpdateTemplateRequest) HasEmailBcc() bool {
+	if o != nil && o.EmailBcc != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailBcc gets a reference to the given []string and assigns it to the EmailBcc field.
+func (o *UpdateTemplateRequest) SetEmailBcc(v []string) {
+	o.EmailBcc = v
+}
+
 // GetIsSMS returns the IsSMS field value if set, zero value otherwise.
 func (o *UpdateTemplateRequest) GetIsSMS() bool {
 	if o == nil || o.IsSMS == nil {
@@ -395,6 +430,9 @@ func (o UpdateTemplateRequest) MarshalJSON() ([]byte, error) {
 	if o.EmailBody.IsSet() {
 		toSerialize["email_body"] = o.EmailBody.Get()
 	}
+	if o.EmailBcc != nil {
+		toSerialize["email_bcc"] = o.EmailBcc
+	}
 	if o.IsSMS != nil {
 		toSerialize["isSMS"] = o.IsSMS
 	}
@@ -426,6 +464,7 @@ func (o *UpdateTemplateRequest) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "isEmail")
 		delete(additionalProperties, "email_subject")
 		delete(additionalProperties, "email_body")
+		delete(additionalProperties, "email_bcc")
 		delete(additionalProperties, "isSMS")
 		delete(additionalProperties, "dynamic_content")
 		o.AdditionalProperties = additionalProperties


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat: add flat create-notification doc examples via vendor extension
- feat: Add email bcc to API client libraries

### 🐛 Bug Fixes
- fix(api): keep CreateNotificationSuccessResponse.errors polymorphic

### 📚 Docs
- docs(api): notification targeting DX and TypeScript doc pipeline (SDK-4395)

---
_Generated from [OneSignal/api-client-libraries@bc71af6...731c23e](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...731c23e829e6ae22d94e605ab87b2a20468e8961)._