### PR TITLE
feat: add v5.5.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2514,10 +2514,19 @@ components:
           nullable: true
           type: array
         include_email_tokens:
-          description: "Recommended for Sending Emails - Target specific email addresses.\n\
-            If an email does not correspond to an existing user, a new user will be\
-            \ created.\nExample: nick@catfac.ts\nLimit of 2,000 entries per REST API\
-            \ call\n"
+          deprecated: true
+          description: "Deprecated alias for `email_to`. Target specific email addresses.\
+            \ If an email does not correspond to an existing user, a new user will\
+            \ be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST\
+            \ API call. Prefer `email_to` in new integrations.\n"
+          items:
+            type: string
+          type: array
+        email_to:
+          description: "Recommended for Sending Emails - Target specific email addresses.\
+            \ If an email does not correspond to an existing user, a new user will\
+            \ be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST\
+            \ API call. Supersedes the deprecated `include_email_tokens` field.\n"
           items:
             type: string
           type: array
@@ -5338,6 +5347,13 @@ components:
           maxItems: 5
           nullable: true
           type: array
+          writeOnly: true
+        email_sender_domain:
+          description: "Channel: Email\nSender domain to use for the email message.\
+            \ Overrides the default sender domain configured for the app. Only supported\
+            \ when the email service provider is OneSignal Email.\n"
+          nullable: true
+          type: string
           writeOnly: true
         sms_from:
           description: "Channel: SMS\nPhone Number used to send SMS. Should be a registered\

--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **IncludedSegments** | Pointer to **[]string** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **ExcludedSegments** | Pointer to **[]string** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **IncludeSubscriptionIds** | Pointer to **[]string** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] 
-**IncludeEmailTokens** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] 
+**IncludeEmailTokens** | Pointer to **[]string** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] 
+**EmailTo** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] 
 **IncludePhoneNumbers** | Pointer to **[]string** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeIosTokens** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeWpWnsUris** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] 
@@ -110,6 +111,7 @@ Name | Type | Description | Notes
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
+**EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -248,6 +250,31 @@ SetIncludeEmailTokens sets IncludeEmailTokens field to given value.
 `func (o *BasicNotification) HasIncludeEmailTokens() bool`
 
 HasIncludeEmailTokens returns a boolean if a field has been set.
+
+### GetEmailTo
+
+`func (o *BasicNotification) GetEmailTo() []string`
+
+GetEmailTo returns the EmailTo field if non-nil, zero value otherwise.
+
+### GetEmailToOk
+
+`func (o *BasicNotification) GetEmailToOk() (*[]string, bool)`
+
+GetEmailToOk returns a tuple with the EmailTo field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailTo
+
+`func (o *BasicNotification) SetEmailTo(v []string)`
+
+SetEmailTo sets EmailTo field to given value.
+
+### HasEmailTo
+
+`func (o *BasicNotification) HasEmailTo() bool`
+
+HasEmailTo returns a boolean if a field has been set.
 
 ### GetIncludePhoneNumbers
 
@@ -3614,6 +3641,41 @@ HasEmailBcc returns a boolean if a field has been set.
 `func (o *BasicNotification) UnsetEmailBcc()`
 
 UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
+### GetEmailSenderDomain
+
+`func (o *BasicNotification) GetEmailSenderDomain() string`
+
+GetEmailSenderDomain returns the EmailSenderDomain field if non-nil, zero value otherwise.
+
+### GetEmailSenderDomainOk
+
+`func (o *BasicNotification) GetEmailSenderDomainOk() (*string, bool)`
+
+GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailSenderDomain
+
+`func (o *BasicNotification) SetEmailSenderDomain(v string)`
+
+SetEmailSenderDomain sets EmailSenderDomain field to given value.
+
+### HasEmailSenderDomain
+
+`func (o *BasicNotification) HasEmailSenderDomain() bool`
+
+HasEmailSenderDomain returns a boolean if a field has been set.
+
+### SetEmailSenderDomainNil
+
+`func (o *BasicNotification) SetEmailSenderDomainNil(b bool)`
+
+ SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+
+### UnsetEmailSenderDomain
+`func (o *BasicNotification) UnsetEmailSenderDomain()`
+
+UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *BasicNotification) GetSmsFrom() string`

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -97,6 +97,7 @@ Name | Type | Description | Notes
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
+**EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -3261,6 +3262,41 @@ HasEmailBcc returns a boolean if a field has been set.
 `func (o *BasicNotificationAllOf) UnsetEmailBcc()`
 
 UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
+### GetEmailSenderDomain
+
+`func (o *BasicNotificationAllOf) GetEmailSenderDomain() string`
+
+GetEmailSenderDomain returns the EmailSenderDomain field if non-nil, zero value otherwise.
+
+### GetEmailSenderDomainOk
+
+`func (o *BasicNotificationAllOf) GetEmailSenderDomainOk() (*string, bool)`
+
+GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailSenderDomain
+
+`func (o *BasicNotificationAllOf) SetEmailSenderDomain(v string)`
+
+SetEmailSenderDomain sets EmailSenderDomain field to given value.
+
+### HasEmailSenderDomain
+
+`func (o *BasicNotificationAllOf) HasEmailSenderDomain() bool`
+
+HasEmailSenderDomain returns a boolean if a field has been set.
+
+### SetEmailSenderDomainNil
+
+`func (o *BasicNotificationAllOf) SetEmailSenderDomainNil(b bool)`
+
+ SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+
+### UnsetEmailSenderDomain
+`func (o *BasicNotificationAllOf) UnsetEmailSenderDomain()`
+
+UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *BasicNotificationAllOf) GetSmsFrom() string`

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **IncludedSegments** | Pointer to **[]string** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **ExcludedSegments** | Pointer to **[]string** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **IncludeSubscriptionIds** | Pointer to **[]string** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] 
-**IncludeEmailTokens** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] 
+**IncludeEmailTokens** | Pointer to **[]string** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] 
+**EmailTo** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] 
 **IncludePhoneNumbers** | Pointer to **[]string** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeIosTokens** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeWpWnsUris** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] 
@@ -110,6 +111,7 @@ Name | Type | Description | Notes
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
+**EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -249,6 +251,31 @@ SetIncludeEmailTokens sets IncludeEmailTokens field to given value.
 `func (o *Notification) HasIncludeEmailTokens() bool`
 
 HasIncludeEmailTokens returns a boolean if a field has been set.
+
+### GetEmailTo
+
+`func (o *Notification) GetEmailTo() []string`
+
+GetEmailTo returns the EmailTo field if non-nil, zero value otherwise.
+
+### GetEmailToOk
+
+`func (o *Notification) GetEmailToOk() (*[]string, bool)`
+
+GetEmailToOk returns a tuple with the EmailTo field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailTo
+
+`func (o *Notification) SetEmailTo(v []string)`
+
+SetEmailTo sets EmailTo field to given value.
+
+### HasEmailTo
+
+`func (o *Notification) HasEmailTo() bool`
+
+HasEmailTo returns a boolean if a field has been set.
 
 ### GetIncludePhoneNumbers
 
@@ -3615,6 +3642,41 @@ HasEmailBcc returns a boolean if a field has been set.
 `func (o *Notification) UnsetEmailBcc()`
 
 UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
+### GetEmailSenderDomain
+
+`func (o *Notification) GetEmailSenderDomain() string`
+
+GetEmailSenderDomain returns the EmailSenderDomain field if non-nil, zero value otherwise.
+
+### GetEmailSenderDomainOk
+
+`func (o *Notification) GetEmailSenderDomainOk() (*string, bool)`
+
+GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailSenderDomain
+
+`func (o *Notification) SetEmailSenderDomain(v string)`
+
+SetEmailSenderDomain sets EmailSenderDomain field to given value.
+
+### HasEmailSenderDomain
+
+`func (o *Notification) HasEmailSenderDomain() bool`
+
+HasEmailSenderDomain returns a boolean if a field has been set.
+
+### SetEmailSenderDomainNil
+
+`func (o *Notification) SetEmailSenderDomainNil(b bool)`
+
+ SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+
+### UnsetEmailSenderDomain
+`func (o *Notification) UnsetEmailSenderDomain()`
+
+UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *Notification) GetSmsFrom() string`

--- a/docs/NotificationTarget.md
+++ b/docs/NotificationTarget.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **IncludedSegments** | Pointer to **[]string** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **ExcludedSegments** | Pointer to **[]string** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **IncludeSubscriptionIds** | Pointer to **[]string** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] 
-**IncludeEmailTokens** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] 
+**IncludeEmailTokens** | Pointer to **[]string** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] 
+**EmailTo** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] 
 **IncludePhoneNumbers** | Pointer to **[]string** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeIosTokens** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeWpWnsUris** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] 
@@ -146,6 +147,31 @@ SetIncludeEmailTokens sets IncludeEmailTokens field to given value.
 `func (o *NotificationTarget) HasIncludeEmailTokens() bool`
 
 HasIncludeEmailTokens returns a boolean if a field has been set.
+
+### GetEmailTo
+
+`func (o *NotificationTarget) GetEmailTo() []string`
+
+GetEmailTo returns the EmailTo field if non-nil, zero value otherwise.
+
+### GetEmailToOk
+
+`func (o *NotificationTarget) GetEmailToOk() (*[]string, bool)`
+
+GetEmailToOk returns a tuple with the EmailTo field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailTo
+
+`func (o *NotificationTarget) SetEmailTo(v []string)`
+
+SetEmailTo sets EmailTo field to given value.
+
+### HasEmailTo
+
+`func (o *NotificationTarget) HasEmailTo() bool`
+
+HasEmailTo returns a boolean if a field has been set.
 
 ### GetIncludePhoneNumbers
 

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **IncludedSegments** | Pointer to **[]string** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **ExcludedSegments** | Pointer to **[]string** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] 
 **IncludeSubscriptionIds** | Pointer to **[]string** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] 
-**IncludeEmailTokens** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] 
+**IncludeEmailTokens** | Pointer to **[]string** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] 
+**EmailTo** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] 
 **IncludePhoneNumbers** | Pointer to **[]string** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeIosTokens** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeWpWnsUris** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] 
@@ -110,6 +111,7 @@ Name | Type | Description | Notes
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
 **IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | BCC recipients that were set on this email notification. | [optional] 
+**EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
 **SmsMediaUrls** | Pointer to **[]string** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] 
 **Filters** | Pointer to [**[]FilterExpression**](FilterExpression.md) |  | [optional] 
@@ -261,6 +263,31 @@ SetIncludeEmailTokens sets IncludeEmailTokens field to given value.
 `func (o *NotificationWithMeta) HasIncludeEmailTokens() bool`
 
 HasIncludeEmailTokens returns a boolean if a field has been set.
+
+### GetEmailTo
+
+`func (o *NotificationWithMeta) GetEmailTo() []string`
+
+GetEmailTo returns the EmailTo field if non-nil, zero value otherwise.
+
+### GetEmailToOk
+
+`func (o *NotificationWithMeta) GetEmailToOk() (*[]string, bool)`
+
+GetEmailToOk returns a tuple with the EmailTo field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailTo
+
+`func (o *NotificationWithMeta) SetEmailTo(v []string)`
+
+SetEmailTo sets EmailTo field to given value.
+
+### HasEmailTo
+
+`func (o *NotificationWithMeta) HasEmailTo() bool`
+
+HasEmailTo returns a boolean if a field has been set.
 
 ### GetIncludePhoneNumbers
 
@@ -3627,6 +3654,41 @@ HasEmailBcc returns a boolean if a field has been set.
 `func (o *NotificationWithMeta) UnsetEmailBcc()`
 
 UnsetEmailBcc ensures that no value is present for EmailBcc, not even an explicit nil
+### GetEmailSenderDomain
+
+`func (o *NotificationWithMeta) GetEmailSenderDomain() string`
+
+GetEmailSenderDomain returns the EmailSenderDomain field if non-nil, zero value otherwise.
+
+### GetEmailSenderDomainOk
+
+`func (o *NotificationWithMeta) GetEmailSenderDomainOk() (*string, bool)`
+
+GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailSenderDomain
+
+`func (o *NotificationWithMeta) SetEmailSenderDomain(v string)`
+
+SetEmailSenderDomain sets EmailSenderDomain field to given value.
+
+### HasEmailSenderDomain
+
+`func (o *NotificationWithMeta) HasEmailSenderDomain() bool`
+
+HasEmailSenderDomain returns a boolean if a field has been set.
+
+### SetEmailSenderDomainNil
+
+`func (o *NotificationWithMeta) SetEmailSenderDomainNil(b bool)`
+
+ SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+
+### UnsetEmailSenderDomain
+`func (o *NotificationWithMeta) UnsetEmailSenderDomain()`
+
+UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
 ### GetSmsFrom
 
 `func (o *NotificationWithMeta) GetSmsFrom() string`

--- a/docs/SubscriptionNotificationTarget.md
+++ b/docs/SubscriptionNotificationTarget.md
@@ -5,7 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **IncludeSubscriptionIds** | Pointer to **[]string** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] 
-**IncludeEmailTokens** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] 
+**IncludeEmailTokens** | Pointer to **[]string** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] 
+**EmailTo** | Pointer to **[]string** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] 
 **IncludePhoneNumbers** | Pointer to **[]string** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeIosTokens** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] 
 **IncludeWpWnsUris** | Pointer to **[]string** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] 
@@ -94,6 +95,31 @@ SetIncludeEmailTokens sets IncludeEmailTokens field to given value.
 `func (o *SubscriptionNotificationTarget) HasIncludeEmailTokens() bool`
 
 HasIncludeEmailTokens returns a boolean if a field has been set.
+
+### GetEmailTo
+
+`func (o *SubscriptionNotificationTarget) GetEmailTo() []string`
+
+GetEmailTo returns the EmailTo field if non-nil, zero value otherwise.
+
+### GetEmailToOk
+
+`func (o *SubscriptionNotificationTarget) GetEmailToOk() (*[]string, bool)`
+
+GetEmailToOk returns a tuple with the EmailTo field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmailTo
+
+`func (o *SubscriptionNotificationTarget) SetEmailTo(v []string)`
+
+SetEmailTo sets EmailTo field to given value.
+
+### HasEmailTo
+
+`func (o *SubscriptionNotificationTarget) HasEmailTo() bool`
+
+HasEmailTo returns a boolean if a field has been set.
 
 ### GetIncludePhoneNumbers
 

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -23,8 +23,11 @@ type BasicNotification struct {
 	ExcludedSegments []string `json:"excluded_segments,omitempty"`
 	// Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
 	IncludeSubscriptionIds []string `json:"include_subscription_ids,omitempty"`
-	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+	// Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
+	// Deprecated
 	IncludeEmailTokens []string `json:"include_email_tokens,omitempty"`
+	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+	EmailTo []string `json:"email_to,omitempty"`
 	// Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
 	IncludePhoneNumbers []string `json:"include_phone_numbers,omitempty"`
 	// Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call 
@@ -222,6 +225,8 @@ type BasicNotification struct {
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
+	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+	EmailSenderDomain NullableString `json:"email_sender_domain,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -360,6 +365,7 @@ func (o *BasicNotification) SetIncludeSubscriptionIds(v []string) {
 }
 
 // GetIncludeEmailTokens returns the IncludeEmailTokens field value if set, zero value otherwise.
+// Deprecated
 func (o *BasicNotification) GetIncludeEmailTokens() []string {
 	if o == nil || o.IncludeEmailTokens == nil {
 		var ret []string
@@ -370,6 +376,7 @@ func (o *BasicNotification) GetIncludeEmailTokens() []string {
 
 // GetIncludeEmailTokensOk returns a tuple with the IncludeEmailTokens field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *BasicNotification) GetIncludeEmailTokensOk() ([]string, bool) {
 	if o == nil || o.IncludeEmailTokens == nil {
 		return nil, false
@@ -387,8 +394,41 @@ func (o *BasicNotification) HasIncludeEmailTokens() bool {
 }
 
 // SetIncludeEmailTokens gets a reference to the given []string and assigns it to the IncludeEmailTokens field.
+// Deprecated
 func (o *BasicNotification) SetIncludeEmailTokens(v []string) {
 	o.IncludeEmailTokens = v
+}
+
+// GetEmailTo returns the EmailTo field value if set, zero value otherwise.
+func (o *BasicNotification) GetEmailTo() []string {
+	if o == nil || o.EmailTo == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailTo
+}
+
+// GetEmailToOk returns a tuple with the EmailTo field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *BasicNotification) GetEmailToOk() ([]string, bool) {
+	if o == nil || o.EmailTo == nil {
+		return nil, false
+	}
+	return o.EmailTo, true
+}
+
+// HasEmailTo returns a boolean if a field has been set.
+func (o *BasicNotification) HasEmailTo() bool {
+	if o != nil && o.EmailTo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailTo gets a reference to the given []string and assigns it to the EmailTo field.
+func (o *BasicNotification) SetEmailTo(v []string) {
+	o.EmailTo = v
 }
 
 // GetIncludePhoneNumbers returns the IncludePhoneNumbers field value if set, zero value otherwise.
@@ -4398,6 +4438,48 @@ func (o *BasicNotification) SetEmailBcc(v []string) {
 	o.EmailBcc = v
 }
 
+// GetEmailSenderDomain returns the EmailSenderDomain field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BasicNotification) GetEmailSenderDomain() string {
+	if o == nil || o.EmailSenderDomain.Get() == nil {
+		var ret string
+		return ret
+	}
+	return *o.EmailSenderDomain.Get()
+}
+
+// GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BasicNotification) GetEmailSenderDomainOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EmailSenderDomain.Get(), o.EmailSenderDomain.IsSet()
+}
+
+// HasEmailSenderDomain returns a boolean if a field has been set.
+func (o *BasicNotification) HasEmailSenderDomain() bool {
+	if o != nil && o.EmailSenderDomain.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailSenderDomain gets a reference to the given NullableString and assigns it to the EmailSenderDomain field.
+func (o *BasicNotification) SetEmailSenderDomain(v string) {
+	o.EmailSenderDomain.Set(&v)
+}
+// SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+func (o *BasicNotification) SetEmailSenderDomainNil() {
+	o.EmailSenderDomain.Set(nil)
+}
+
+// UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
+func (o *BasicNotification) UnsetEmailSenderDomain() {
+	o.EmailSenderDomain.Unset()
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotification) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -4763,6 +4845,9 @@ func (o BasicNotification) MarshalJSON() ([]byte, error) {
 	if o.IncludeEmailTokens != nil {
 		toSerialize["include_email_tokens"] = o.IncludeEmailTokens
 	}
+	if o.EmailTo != nil {
+		toSerialize["email_to"] = o.EmailTo
+	}
 	if o.IncludePhoneNumbers != nil {
 		toSerialize["include_phone_numbers"] = o.IncludePhoneNumbers
 	}
@@ -5069,6 +5154,9 @@ func (o BasicNotification) MarshalJSON() ([]byte, error) {
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc
 	}
+	if o.EmailSenderDomain.IsSet() {
+		toSerialize["email_sender_domain"] = o.EmailSenderDomain.Get()
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5118,6 +5206,7 @@ func (o *BasicNotification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "excluded_segments")
 		delete(additionalProperties, "include_subscription_ids")
 		delete(additionalProperties, "include_email_tokens")
+		delete(additionalProperties, "email_to")
 		delete(additionalProperties, "include_phone_numbers")
 		delete(additionalProperties, "include_ios_tokens")
 		delete(additionalProperties, "include_wp_wns_uris")
@@ -5220,6 +5309,7 @@ func (o *BasicNotification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
 		delete(additionalProperties, "email_bcc")
+		delete(additionalProperties, "email_sender_domain")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -197,6 +197,8 @@ type BasicNotificationAllOf struct {
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
+	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+	EmailSenderDomain NullableString `json:"email_sender_domain,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -3962,6 +3964,48 @@ func (o *BasicNotificationAllOf) SetEmailBcc(v []string) {
 	o.EmailBcc = v
 }
 
+// GetEmailSenderDomain returns the EmailSenderDomain field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BasicNotificationAllOf) GetEmailSenderDomain() string {
+	if o == nil || o.EmailSenderDomain.Get() == nil {
+		var ret string
+		return ret
+	}
+	return *o.EmailSenderDomain.Get()
+}
+
+// GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BasicNotificationAllOf) GetEmailSenderDomainOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EmailSenderDomain.Get(), o.EmailSenderDomain.IsSet()
+}
+
+// HasEmailSenderDomain returns a boolean if a field has been set.
+func (o *BasicNotificationAllOf) HasEmailSenderDomain() bool {
+	if o != nil && o.EmailSenderDomain.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailSenderDomain gets a reference to the given NullableString and assigns it to the EmailSenderDomain field.
+func (o *BasicNotificationAllOf) SetEmailSenderDomain(v string) {
+	o.EmailSenderDomain.Set(&v)
+}
+// SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+func (o *BasicNotificationAllOf) SetEmailSenderDomainNil() {
+	o.EmailSenderDomain.Set(nil)
+}
+
+// UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
+func (o *BasicNotificationAllOf) UnsetEmailSenderDomain() {
+	o.EmailSenderDomain.Unset()
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotificationAllOf) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -4594,6 +4638,9 @@ func (o BasicNotificationAllOf) MarshalJSON() ([]byte, error) {
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc
 	}
+	if o.EmailSenderDomain.IsSet() {
+		toSerialize["email_sender_domain"] = o.EmailSenderDomain.Get()
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -4732,6 +4779,7 @@ func (o *BasicNotificationAllOf) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
 		delete(additionalProperties, "email_bcc")
+		delete(additionalProperties, "email_sender_domain")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_notification.go
+++ b/model_notification.go
@@ -24,8 +24,11 @@ type Notification struct {
 	ExcludedSegments []string `json:"excluded_segments,omitempty"`
 	// Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
 	IncludeSubscriptionIds []string `json:"include_subscription_ids,omitempty"`
-	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+	// Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
+	// Deprecated
 	IncludeEmailTokens []string `json:"include_email_tokens,omitempty"`
+	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+	EmailTo []string `json:"email_to,omitempty"`
 	// Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
 	IncludePhoneNumbers []string `json:"include_phone_numbers,omitempty"`
 	// Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call 
@@ -223,6 +226,8 @@ type Notification struct {
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
+	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+	EmailSenderDomain NullableString `json:"email_sender_domain,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -363,6 +368,7 @@ func (o *Notification) SetIncludeSubscriptionIds(v []string) {
 }
 
 // GetIncludeEmailTokens returns the IncludeEmailTokens field value if set, zero value otherwise.
+// Deprecated
 func (o *Notification) GetIncludeEmailTokens() []string {
 	if o == nil || o.IncludeEmailTokens == nil {
 		var ret []string
@@ -373,6 +379,7 @@ func (o *Notification) GetIncludeEmailTokens() []string {
 
 // GetIncludeEmailTokensOk returns a tuple with the IncludeEmailTokens field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *Notification) GetIncludeEmailTokensOk() ([]string, bool) {
 	if o == nil || o.IncludeEmailTokens == nil {
 		return nil, false
@@ -390,8 +397,41 @@ func (o *Notification) HasIncludeEmailTokens() bool {
 }
 
 // SetIncludeEmailTokens gets a reference to the given []string and assigns it to the IncludeEmailTokens field.
+// Deprecated
 func (o *Notification) SetIncludeEmailTokens(v []string) {
 	o.IncludeEmailTokens = v
+}
+
+// GetEmailTo returns the EmailTo field value if set, zero value otherwise.
+func (o *Notification) GetEmailTo() []string {
+	if o == nil || o.EmailTo == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailTo
+}
+
+// GetEmailToOk returns a tuple with the EmailTo field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Notification) GetEmailToOk() ([]string, bool) {
+	if o == nil || o.EmailTo == nil {
+		return nil, false
+	}
+	return o.EmailTo, true
+}
+
+// HasEmailTo returns a boolean if a field has been set.
+func (o *Notification) HasEmailTo() bool {
+	if o != nil && o.EmailTo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailTo gets a reference to the given []string and assigns it to the EmailTo field.
+func (o *Notification) SetEmailTo(v []string) {
+	o.EmailTo = v
 }
 
 // GetIncludePhoneNumbers returns the IncludePhoneNumbers field value if set, zero value otherwise.
@@ -4401,6 +4441,48 @@ func (o *Notification) SetEmailBcc(v []string) {
 	o.EmailBcc = v
 }
 
+// GetEmailSenderDomain returns the EmailSenderDomain field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Notification) GetEmailSenderDomain() string {
+	if o == nil || o.EmailSenderDomain.Get() == nil {
+		var ret string
+		return ret
+	}
+	return *o.EmailSenderDomain.Get()
+}
+
+// GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *Notification) GetEmailSenderDomainOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EmailSenderDomain.Get(), o.EmailSenderDomain.IsSet()
+}
+
+// HasEmailSenderDomain returns a boolean if a field has been set.
+func (o *Notification) HasEmailSenderDomain() bool {
+	if o != nil && o.EmailSenderDomain.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailSenderDomain gets a reference to the given NullableString and assigns it to the EmailSenderDomain field.
+func (o *Notification) SetEmailSenderDomain(v string) {
+	o.EmailSenderDomain.Set(&v)
+}
+// SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+func (o *Notification) SetEmailSenderDomainNil() {
+	o.EmailSenderDomain.Set(nil)
+}
+
+// UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
+func (o *Notification) UnsetEmailSenderDomain() {
+	o.EmailSenderDomain.Unset()
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Notification) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -4808,6 +4890,9 @@ func (o Notification) MarshalJSON() ([]byte, error) {
 	if o.IncludeEmailTokens != nil {
 		toSerialize["include_email_tokens"] = o.IncludeEmailTokens
 	}
+	if o.EmailTo != nil {
+		toSerialize["email_to"] = o.EmailTo
+	}
 	if o.IncludePhoneNumbers != nil {
 		toSerialize["include_phone_numbers"] = o.IncludePhoneNumbers
 	}
@@ -5114,6 +5199,9 @@ func (o Notification) MarshalJSON() ([]byte, error) {
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc
 	}
+	if o.EmailSenderDomain.IsSet() {
+		toSerialize["email_sender_domain"] = o.EmailSenderDomain.Get()
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5166,6 +5254,7 @@ func (o *Notification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "excluded_segments")
 		delete(additionalProperties, "include_subscription_ids")
 		delete(additionalProperties, "include_email_tokens")
+		delete(additionalProperties, "email_to")
 		delete(additionalProperties, "include_phone_numbers")
 		delete(additionalProperties, "include_ios_tokens")
 		delete(additionalProperties, "include_wp_wns_uris")
@@ -5268,6 +5357,7 @@ func (o *Notification) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
 		delete(additionalProperties, "email_bcc")
+		delete(additionalProperties, "email_sender_domain")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -23,8 +23,11 @@ type NotificationWithMeta struct {
 	ExcludedSegments []string `json:"excluded_segments,omitempty"`
 	// Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
 	IncludeSubscriptionIds []string `json:"include_subscription_ids,omitempty"`
-	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+	// Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
+	// Deprecated
 	IncludeEmailTokens []string `json:"include_email_tokens,omitempty"`
+	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+	EmailTo []string `json:"email_to,omitempty"`
 	// Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
 	IncludePhoneNumbers []string `json:"include_phone_numbers,omitempty"`
 	// Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call 
@@ -222,6 +225,8 @@ type NotificationWithMeta struct {
 	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
 	// BCC recipients that were set on this email notification.
 	EmailBcc []string `json:"email_bcc,omitempty"`
+	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+	EmailSenderDomain NullableString `json:"email_sender_domain,omitempty"`
 	// Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
 	SmsFrom NullableString `json:"sms_from,omitempty"`
 	// Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs. 
@@ -384,6 +389,7 @@ func (o *NotificationWithMeta) SetIncludeSubscriptionIds(v []string) {
 }
 
 // GetIncludeEmailTokens returns the IncludeEmailTokens field value if set, zero value otherwise.
+// Deprecated
 func (o *NotificationWithMeta) GetIncludeEmailTokens() []string {
 	if o == nil || o.IncludeEmailTokens == nil {
 		var ret []string
@@ -394,6 +400,7 @@ func (o *NotificationWithMeta) GetIncludeEmailTokens() []string {
 
 // GetIncludeEmailTokensOk returns a tuple with the IncludeEmailTokens field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *NotificationWithMeta) GetIncludeEmailTokensOk() ([]string, bool) {
 	if o == nil || o.IncludeEmailTokens == nil {
 		return nil, false
@@ -411,8 +418,41 @@ func (o *NotificationWithMeta) HasIncludeEmailTokens() bool {
 }
 
 // SetIncludeEmailTokens gets a reference to the given []string and assigns it to the IncludeEmailTokens field.
+// Deprecated
 func (o *NotificationWithMeta) SetIncludeEmailTokens(v []string) {
 	o.IncludeEmailTokens = v
+}
+
+// GetEmailTo returns the EmailTo field value if set, zero value otherwise.
+func (o *NotificationWithMeta) GetEmailTo() []string {
+	if o == nil || o.EmailTo == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailTo
+}
+
+// GetEmailToOk returns a tuple with the EmailTo field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *NotificationWithMeta) GetEmailToOk() ([]string, bool) {
+	if o == nil || o.EmailTo == nil {
+		return nil, false
+	}
+	return o.EmailTo, true
+}
+
+// HasEmailTo returns a boolean if a field has been set.
+func (o *NotificationWithMeta) HasEmailTo() bool {
+	if o != nil && o.EmailTo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailTo gets a reference to the given []string and assigns it to the EmailTo field.
+func (o *NotificationWithMeta) SetEmailTo(v []string) {
+	o.EmailTo = v
 }
 
 // GetIncludePhoneNumbers returns the IncludePhoneNumbers field value if set, zero value otherwise.
@@ -4422,6 +4462,48 @@ func (o *NotificationWithMeta) SetEmailBcc(v []string) {
 	o.EmailBcc = v
 }
 
+// GetEmailSenderDomain returns the EmailSenderDomain field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NotificationWithMeta) GetEmailSenderDomain() string {
+	if o == nil || o.EmailSenderDomain.Get() == nil {
+		var ret string
+		return ret
+	}
+	return *o.EmailSenderDomain.Get()
+}
+
+// GetEmailSenderDomainOk returns a tuple with the EmailSenderDomain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NotificationWithMeta) GetEmailSenderDomainOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EmailSenderDomain.Get(), o.EmailSenderDomain.IsSet()
+}
+
+// HasEmailSenderDomain returns a boolean if a field has been set.
+func (o *NotificationWithMeta) HasEmailSenderDomain() bool {
+	if o != nil && o.EmailSenderDomain.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailSenderDomain gets a reference to the given NullableString and assigns it to the EmailSenderDomain field.
+func (o *NotificationWithMeta) SetEmailSenderDomain(v string) {
+	o.EmailSenderDomain.Set(&v)
+}
+// SetEmailSenderDomainNil sets the value for EmailSenderDomain to be an explicit nil
+func (o *NotificationWithMeta) SetEmailSenderDomainNil() {
+	o.EmailSenderDomain.Set(nil)
+}
+
+// UnsetEmailSenderDomain ensures that no value is present for EmailSenderDomain, not even an explicit nil
+func (o *NotificationWithMeta) UnsetEmailSenderDomain() {
+	o.EmailSenderDomain.Unset()
+}
+
 // GetSmsFrom returns the SmsFrom field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NotificationWithMeta) GetSmsFrom() string {
 	if o == nil || o.SmsFrom.Get() == nil {
@@ -5243,6 +5325,9 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	if o.IncludeEmailTokens != nil {
 		toSerialize["include_email_tokens"] = o.IncludeEmailTokens
 	}
+	if o.EmailTo != nil {
+		toSerialize["email_to"] = o.EmailTo
+	}
 	if o.IncludePhoneNumbers != nil {
 		toSerialize["include_phone_numbers"] = o.IncludePhoneNumbers
 	}
@@ -5549,6 +5634,9 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc
 	}
+	if o.EmailSenderDomain.IsSet() {
+		toSerialize["email_sender_domain"] = o.EmailSenderDomain.Get()
+	}
 	if o.SmsFrom.IsSet() {
 		toSerialize["sms_from"] = o.SmsFrom.Get()
 	}
@@ -5637,6 +5725,7 @@ func (o *NotificationWithMeta) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "excluded_segments")
 		delete(additionalProperties, "include_subscription_ids")
 		delete(additionalProperties, "include_email_tokens")
+		delete(additionalProperties, "email_to")
 		delete(additionalProperties, "include_phone_numbers")
 		delete(additionalProperties, "include_ios_tokens")
 		delete(additionalProperties, "include_wp_wns_uris")
@@ -5739,6 +5828,7 @@ func (o *NotificationWithMeta) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "disable_email_click_tracking")
 		delete(additionalProperties, "include_unsubscribed")
 		delete(additionalProperties, "email_bcc")
+		delete(additionalProperties, "email_sender_domain")
 		delete(additionalProperties, "sms_from")
 		delete(additionalProperties, "sms_media_urls")
 		delete(additionalProperties, "filters")

--- a/model_subscription_notification_target.go
+++ b/model_subscription_notification_target.go
@@ -19,8 +19,11 @@ import (
 type SubscriptionNotificationTarget struct {
 	// Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
 	IncludeSubscriptionIds []string `json:"include_subscription_ids,omitempty"`
-	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+	// Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
+	// Deprecated
 	IncludeEmailTokens []string `json:"include_email_tokens,omitempty"`
+	// Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+	EmailTo []string `json:"email_to,omitempty"`
 	// Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
 	IncludePhoneNumbers []string `json:"include_phone_numbers,omitempty"`
 	// Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call 
@@ -94,6 +97,7 @@ func (o *SubscriptionNotificationTarget) SetIncludeSubscriptionIds(v []string) {
 }
 
 // GetIncludeEmailTokens returns the IncludeEmailTokens field value if set, zero value otherwise.
+// Deprecated
 func (o *SubscriptionNotificationTarget) GetIncludeEmailTokens() []string {
 	if o == nil || o.IncludeEmailTokens == nil {
 		var ret []string
@@ -104,6 +108,7 @@ func (o *SubscriptionNotificationTarget) GetIncludeEmailTokens() []string {
 
 // GetIncludeEmailTokensOk returns a tuple with the IncludeEmailTokens field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *SubscriptionNotificationTarget) GetIncludeEmailTokensOk() ([]string, bool) {
 	if o == nil || o.IncludeEmailTokens == nil {
 		return nil, false
@@ -121,8 +126,41 @@ func (o *SubscriptionNotificationTarget) HasIncludeEmailTokens() bool {
 }
 
 // SetIncludeEmailTokens gets a reference to the given []string and assigns it to the IncludeEmailTokens field.
+// Deprecated
 func (o *SubscriptionNotificationTarget) SetIncludeEmailTokens(v []string) {
 	o.IncludeEmailTokens = v
+}
+
+// GetEmailTo returns the EmailTo field value if set, zero value otherwise.
+func (o *SubscriptionNotificationTarget) GetEmailTo() []string {
+	if o == nil || o.EmailTo == nil {
+		var ret []string
+		return ret
+	}
+	return o.EmailTo
+}
+
+// GetEmailToOk returns a tuple with the EmailTo field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SubscriptionNotificationTarget) GetEmailToOk() ([]string, bool) {
+	if o == nil || o.EmailTo == nil {
+		return nil, false
+	}
+	return o.EmailTo, true
+}
+
+// HasEmailTo returns a boolean if a field has been set.
+func (o *SubscriptionNotificationTarget) HasEmailTo() bool {
+	if o != nil && o.EmailTo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmailTo gets a reference to the given []string and assigns it to the EmailTo field.
+func (o *SubscriptionNotificationTarget) SetEmailTo(v []string) {
+	o.EmailTo = v
 }
 
 // GetIncludePhoneNumbers returns the IncludePhoneNumbers field value if set, zero value otherwise.
@@ -422,6 +460,9 @@ func (o SubscriptionNotificationTarget) MarshalJSON() ([]byte, error) {
 	if o.IncludeEmailTokens != nil {
 		toSerialize["include_email_tokens"] = o.IncludeEmailTokens
 	}
+	if o.EmailTo != nil {
+		toSerialize["email_to"] = o.EmailTo
+	}
 	if o.IncludePhoneNumbers != nil {
 		toSerialize["include_phone_numbers"] = o.IncludePhoneNumbers
 	}
@@ -469,6 +510,7 @@ func (o *SubscriptionNotificationTarget) UnmarshalJSON(bytes []byte) (err error)
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "include_subscription_ids")
 		delete(additionalProperties, "include_email_tokens")
+		delete(additionalProperties, "email_to")
 		delete(additionalProperties, "include_phone_numbers")
 		delete(additionalProperties, "include_ios_tokens")
 		delete(additionalProperties, "include_wp_wns_uris")


### PR DESCRIPTION
## Release v5.5.0

### 🚀 Features
- feat: deprecate `include_email_tokens` in favor of `email_to`; add `email_sender_domain`

---
_Generated from [OneSignal/api-client-libraries@5306c76...b695464](https://github.com/OneSignal/api-client-libraries/compare/5306c7671b1f6194f9800bcf976df0accae3ae8e...b695464f2c408308b9f7c8beb8cd7c0147dd565f)._