### PR TITLE
feat: add v5.6.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,6 +23,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - description: How many notifications to return.  Max is 50.  Default is 50.
@@ -31,6 +32,7 @@ paths:
         name: limit
         required: false
         schema:
+          example: 10
           type: integer
         style: form
       - description: Page offset.  Default is 0.  Results are sorted by queued_at
@@ -41,6 +43,7 @@ paths:
         name: offset
         required: false
         schema:
+          example: 0
           type: integer
         style: form
       - description: |
@@ -58,6 +61,7 @@ paths:
           - 0
           - 1
           - 3
+          example: 0
           type: integer
         style: form
       responses:
@@ -144,6 +148,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - explode: false
@@ -151,6 +156,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       responses:
@@ -191,6 +197,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - explode: false
@@ -198,6 +205,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       responses:
@@ -252,6 +260,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       requestBody:
@@ -376,6 +385,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       responses:
@@ -411,6 +421,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -452,6 +463,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "Segments are listed in ascending order of created_at date. offset\
@@ -462,6 +474,7 @@ paths:
         name: offset
         required: false
         schema:
+          example: 0
           type: integer
         style: form
       - description: The amount of Segments in the response. Maximum 300.
@@ -470,6 +483,7 @@ paths:
         name: limit
         required: false
         schema:
+          example: 10
           type: integer
         style: form
       responses:
@@ -511,6 +525,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -562,6 +577,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The segment_id can be found in the URL of the segment when viewing
@@ -571,6 +587,7 @@ paths:
         name: segment_id
         required: true
         schema:
+          example: d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e
           type: string
         style: simple
       responses:
@@ -616,6 +633,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "Required\nComma-separated list of names and the value (sum/count)\
@@ -628,6 +646,7 @@ paths:
         name: outcome_names
         required: true
         schema:
+          example: "os__session_duration.count,os__click.count"
           type: string
         style: form
       - description: "Optional\nIf outcome names contain any commas, then please specify\
@@ -639,6 +658,7 @@ paths:
         name: "outcome_names[]"
         required: false
         schema:
+          example: os__session_duration.count
           type: string
         style: form
       - description: "Optional\nTime range for the returned data. The values can be\
@@ -649,6 +669,7 @@ paths:
         name: outcome_time_range
         required: false
         schema:
+          example: 1d
           type: string
         style: form
       - description: "Optional\nPlatform id. Refer device's platform ids for values.\n\
@@ -659,6 +680,7 @@ paths:
         name: outcome_platforms
         required: false
         schema:
+          example: "0,1"
           type: string
         style: form
       - description: "Optional\nAttribution type for the outcomes. The values can\
@@ -670,6 +692,7 @@ paths:
         name: outcome_attribution
         required: false
         schema:
+          example: direct
           type: string
         style: form
       responses:
@@ -706,6 +729,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The name of the Live Activity defined in your app. This should
@@ -715,6 +739,7 @@ paths:
         name: activity_type
         required: true
         schema:
+          example: order_status
           type: string
         style: simple
       requestBody:
@@ -756,6 +781,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: Live Activity record ID
@@ -764,6 +790,7 @@ paths:
         name: activity_id
         required: true
         schema:
+          example: "12345"
           type: string
         style: simple
       requestBody:
@@ -806,6 +833,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -864,6 +892,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -871,6 +900,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -878,6 +908,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -912,6 +943,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -919,6 +951,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -926,6 +959,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -964,6 +998,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -971,6 +1006,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -978,6 +1014,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1023,6 +1060,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1030,6 +1068,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1037,6 +1076,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -1076,6 +1116,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1083,6 +1124,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1090,6 +1132,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1141,6 +1184,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1148,6 +1192,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1155,6 +1200,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       - explode: false
@@ -1162,6 +1208,7 @@ paths:
         name: alias_label_to_delete
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       responses:
@@ -1208,6 +1255,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1215,6 +1263,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1222,6 +1271,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1280,6 +1330,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1287,6 +1338,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       responses:
@@ -1327,6 +1379,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1334,6 +1387,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1381,6 +1435,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1388,6 +1443,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       responses:
@@ -1420,6 +1476,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1427,6 +1484,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1479,6 +1537,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1486,6 +1545,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1539,6 +1599,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The type of token to use when looking up the subscription. See
@@ -1548,6 +1609,7 @@ paths:
         name: token_type
         required: true
         schema:
+          example: Email
           type: string
         style: simple
       - description: "The value of the token to lookup by (e.g., email address, phone\
@@ -1557,6 +1619,7 @@ paths:
         name: token
         required: true
         schema:
+          example: user@example.com
           type: string
         style: simple
       requestBody:
@@ -1599,6 +1662,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "The id of the message found in the creation notification POST\
@@ -1608,6 +1672,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       - description: "The unsubscribe token that is generated via liquid syntax in\
@@ -1617,6 +1682,7 @@ paths:
         name: token
         required: true
         schema:
+          example: YOUR_TOKEN_ID
           type: string
         style: form
       responses:
@@ -1693,6 +1759,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -1752,6 +1819,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       - description: The ID of the app that the notification belongs to.
@@ -1760,6 +1828,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -1801,6 +1870,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - description: Maximum number of templates. Default and max is 50.
@@ -1810,6 +1880,7 @@ paths:
         required: false
         schema:
           default: 50
+          example: 10
           type: integer
         style: form
       - description: Pagination offset.
@@ -1819,6 +1890,7 @@ paths:
         required: false
         schema:
           default: 0
+          example: 0
           type: integer
         style: form
       - description: Filter by delivery channel.
@@ -1831,6 +1903,7 @@ paths:
           - push
           - email
           - sms
+          example: push
           type: string
         style: form
       responses:
@@ -1896,6 +1969,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -1903,6 +1977,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -1936,6 +2011,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -1943,6 +2019,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -1976,6 +2053,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -1983,6 +2061,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       requestBody:
@@ -2017,6 +2096,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -2024,6 +2104,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       requestBody:
@@ -2059,6 +2140,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       responses:
@@ -2089,6 +2171,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -2125,6 +2208,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2132,6 +2216,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       responses:
@@ -2160,6 +2245,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2167,6 +2253,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       requestBody:
@@ -2204,6 +2291,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2211,6 +2299,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       responses:
@@ -2242,6 +2331,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -77,8 +77,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    notificationId := "notificationId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -90,6 +90,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CancelNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CancelNotification`: GenericSuccessBoolResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CancelNotification`: %v\n", resp)
@@ -153,8 +156,8 @@ import (
 )
 
 func main() {
-    templateId := "templateId_example" // string | 
-    appId := "appId_example" // string | 
+    templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
     copyTemplateRequest := *onesignal.NewCopyTemplateRequest("TargetAppId_example") // CopyTemplateRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -167,6 +170,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CopyTemplateToApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CopyTemplateToApp`: TemplateResource
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CopyTemplateToApp`: %v\n", resp)
@@ -231,9 +237,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     userIdentityBody := *onesignal.NewUserIdentityBody() // UserIdentityBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -246,6 +252,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateAlias`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateAlias`: %v\n", resp)
@@ -313,8 +322,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    subscriptionId := "subscriptionId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     userIdentityBody := *onesignal.NewUserIdentityBody() // UserIdentityBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -327,6 +336,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAliasBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateAliasBySubscription`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateAliasBySubscription`: %v\n", resp)
@@ -392,7 +404,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
     createApiKeyRequest := *onesignal.NewCreateApiKeyRequest() // CreateApiKeyRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -405,6 +417,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateApiKey`: CreateApiKeyResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateApiKey`: %v\n", resp)
@@ -480,6 +495,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateApp`: App
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateApp`: %v\n", resp)
@@ -538,7 +556,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | Your OneSignal App ID in UUID v4 format.
+    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
     customEventsRequest := *onesignal.NewCustomEventsRequest([]onesignal.CustomEvent{*onesignal.NewCustomEvent("Name_example")}) // CustomEventsRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -551,6 +569,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateCustomEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateCustomEvents`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateCustomEvents`: %v\n", resp)
@@ -610,6 +631,7 @@ import (
     "fmt"
     "os"
 
+    "github.com/google/uuid"
     "github.com/OneSignal/onesignal-go-api"
 )
 
@@ -625,13 +647,35 @@ func main() {
     notification.SetContents(*contents)
     notification.SetIncludeAliases(map[string][]string{"external_id": {"YOUR_USER_EXTERNAL_ID"}})
     notification.SetTargetChannel("push")
+    // Idempotency key: a client-generated UUID that lets you safely retry on network failure.
+    // If two requests arrive with the same key inside the 30-day window, only the first is
+    // sent and the second returns the original response. The `github.com/google/uuid` module
+    // is not a declared dep of this SDK; run `go get github.com/google/uuid` (or `go mod tidy`
+    // after importing it) before building. DO NOT reuse keys across logically distinct sends.
+    notification.SetIdempotencyKey(uuid.NewString())
 
     resp, r, err := apiClient.DefaultApi.CreateNotification(restAuth).Notification(*notification).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
+        return
     }
-    fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateNotification`: %v\n", resp)
+    // `resp.GetId()` discriminates the two HTTP 200 shapes. An empty string means no
+    // notification was created (e.g. all targets were unreachable / not subscribed).
+    // `resp.GetErrors()` is `interface{}` because the field is polymorphic: a `[]string` in
+    // the no-subscribers case, or a map keyed by recipient-identifier type
+    // (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...) when
+    // the notification WAS created but some recipients were skipped.
+    if resp.GetId() == "" {
+        fmt.Fprintf(os.Stderr, "Notification was not sent: %v\n", resp.GetErrors())
+    } else if errors := resp.GetErrors(); errors != nil {
+        fmt.Fprintf(os.Stdout, "Notification created: %s (partial failures: %v)\n", resp.GetId(), errors)
+    } else {
+        fmt.Fprintf(os.Stdout, "Notification created: %s\n", resp.GetId())
+    }
 }
 ```
 
@@ -687,7 +731,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     segment := *onesignal.NewSegment("Name_example", []onesignal.FilterExpression{onesignal.FilterExpression{Filter: onesignal.NewFilter()}}) // Segment |  (optional)
 
     configuration := onesignal.NewConfiguration()
@@ -700,6 +744,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateSegment`: CreateSegmentSuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateSegment`: %v\n", resp)
@@ -763,9 +810,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -778,6 +825,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateSubscription`: SubscriptionBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateSubscription`: %v\n", resp)
@@ -857,6 +907,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateTemplate`: TemplateResource
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateTemplate`: %v\n", resp)
@@ -915,7 +968,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
     user := *onesignal.NewUser() // User | 
 
     configuration := onesignal.NewConfiguration()
@@ -928,6 +981,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `CreateUser`: User
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateUser`: %v\n", resp)
@@ -991,10 +1047,10 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
-    aliasLabelToDelete := "aliasLabelToDelete_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
+    aliasLabelToDelete := "external_id" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1006,6 +1062,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `DeleteAlias`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.DeleteAlias`: %v\n", resp)
@@ -1074,8 +1133,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    tokenId := "tokenId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1087,6 +1146,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `DeleteApiKey`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.DeleteApiKey`: %v\n", resp)
@@ -1151,8 +1213,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    segmentId := "segmentId_example" // string | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    segmentId := "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e" // string | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1164,6 +1226,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `DeleteSegment`: GenericSuccessBoolResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.DeleteSegment`: %v\n", resp)
@@ -1228,8 +1293,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    subscriptionId := "subscriptionId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1241,6 +1306,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
 }
 ```
@@ -1303,8 +1371,8 @@ import (
 )
 
 func main() {
-    templateId := "templateId_example" // string | 
-    appId := "appId_example" // string | 
+    templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1316,6 +1384,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `DeleteTemplate`: GenericSuccessBoolResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.DeleteTemplate`: %v\n", resp)
@@ -1379,9 +1450,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1393,6 +1464,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
 }
 ```
@@ -1457,8 +1531,8 @@ import (
 )
 
 func main() {
-    notificationId := "notificationId_example" // string | The ID of the notification to export events from.
-    appId := "appId_example" // string | The ID of the app that the notification belongs to.
+    notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | The ID of the notification to export events from.
+    appId := "00000000-0000-0000-0000-000000000000" // string | The ID of the app that the notification belongs to.
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1470,6 +1544,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `ExportEvents`: ExportEventsSuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ExportEvents`: %v\n", resp)
@@ -1533,7 +1610,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The app ID that you want to export devices from
+    appId := "00000000-0000-0000-0000-000000000000" // string | The app ID that you want to export devices from
     exportSubscriptionsRequestBody := *onesignal.NewExportSubscriptionsRequestBody() // ExportSubscriptionsRequestBody |  (optional)
 
     configuration := onesignal.NewConfiguration()
@@ -1546,6 +1623,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportSubscriptions``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `ExportSubscriptions`: ExportSubscriptionsSuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ExportSubscriptions`: %v\n", resp)
@@ -1609,9 +1689,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1623,6 +1703,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliases``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetAliases`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetAliases`: %v\n", resp)
@@ -1689,8 +1772,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    subscriptionId := "subscriptionId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1702,6 +1785,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliasesBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetAliasesBySubscription`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetAliasesBySubscription`: %v\n", resp)
@@ -1766,7 +1852,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | An app id
+    appId := "00000000-0000-0000-0000-000000000000" // string | An app id
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1778,6 +1864,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetApp`: App
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetApp`: %v\n", resp)
@@ -1851,6 +1940,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApps``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetApps`: []App
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetApps`: %v\n", resp)
@@ -1905,8 +1997,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    notificationId := "notificationId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1918,6 +2010,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetNotification`: NotificationWithMeta
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetNotification`: %v\n", resp)
@@ -1981,7 +2076,7 @@ import (
 )
 
 func main() {
-    notificationId := "notificationId_example" // string | The \"id\" of the message found in the Notification object
+    notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | The \"id\" of the message found in the Notification object
     getNotificationHistoryRequestBody := *onesignal.NewGetNotificationHistoryRequestBody() // GetNotificationHistoryRequestBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -1994,6 +2089,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotificationHistory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetNotificationHistory`: NotificationHistorySuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetNotificationHistory`: %v\n", resp)
@@ -2057,10 +2155,10 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The app ID that you want to view notifications from
-    limit := int32(56) // int32 | How many notifications to return.  Max is 50.  Default is 50. (optional)
-    offset := int32(56) // int32 | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
-    kind := int32(56) // int32 | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional)
+    appId := "00000000-0000-0000-0000-000000000000" // string | The app ID that you want to view notifications from
+    limit := int32(10) // int32 | How many notifications to return.  Max is 50.  Default is 50. (optional)
+    offset := int32(0) // int32 | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
+    kind := int32(0) // int32 | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2072,6 +2170,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotifications``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetNotifications`: NotificationSlice
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetNotifications`: %v\n", resp)
@@ -2133,12 +2234,12 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    outcomeNames := "outcomeNames_example" // string | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
-    outcomeNames2 := "outcomeNames_example" // string | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional)
-    outcomeTimeRange := "outcomeTimeRange_example" // string | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional)
-    outcomePlatforms := "outcomePlatforms_example" // string | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional)
-    outcomeAttribution := "outcomeAttribution_example" // string | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional)
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    outcomeNames := "os__session_duration.count,os__click.count" // string | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
+    outcomeNames2 := "os__session_duration.count" // string | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional)
+    outcomeTimeRange := "1d" // string | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional)
+    outcomePlatforms := "0,1" // string | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional)
+    outcomeAttribution := "direct" // string | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2150,6 +2251,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetOutcomes``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetOutcomes`: OutcomesData
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetOutcomes`: %v\n", resp)
@@ -2217,9 +2321,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    offset := int32(56) // int32 | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional)
-    limit := int32(56) // int32 | The amount of Segments in the response. Maximum 300. (optional)
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    offset := int32(0) // int32 | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional)
+    limit := int32(10) // int32 | The amount of Segments in the response. Maximum 300. (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2231,6 +2335,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetSegments``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetSegments`: GetSegmentsSuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetSegments`: %v\n", resp)
@@ -2295,9 +2402,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2309,6 +2416,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `GetUser`: User
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.GetUser`: %v\n", resp)
@@ -2375,8 +2485,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    tokenId := "tokenId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2388,6 +2498,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.RotateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `RotateApiKey`: CreateApiKeyResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.RotateApiKey`: %v\n", resp)
@@ -2452,8 +2565,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | Your OneSignal App ID in UUID v4 format.
-    activityType := "activityType_example" // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
+    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    activityType := "order_status" // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
     startLiveActivityRequest := *onesignal.NewStartLiveActivityRequest("Name_example", "Event_example", "ActivityId_example", map[string]interface{}(123), map[string]interface{}(123), *onesignal.NewLanguageStringMap(), *onesignal.NewLanguageStringMap()) // StartLiveActivityRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -2466,6 +2579,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.StartLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `StartLiveActivity`: StartLiveActivitySuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.StartLiveActivity`: %v\n", resp)
@@ -2531,8 +2647,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    subscriptionId := "subscriptionId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     transferSubscriptionRequestBody := *onesignal.NewTransferSubscriptionRequestBody() // TransferSubscriptionRequestBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -2545,6 +2661,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.TransferSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `TransferSubscription`: UserIdentityBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.TransferSubscription`: %v\n", resp)
@@ -2610,9 +2729,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    notificationId := "notificationId_example" // string | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
-    token := "token_example" // string | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
+    token := "YOUR_TOKEN_ID" // string | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2624,6 +2743,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UnsubscribeEmailWithToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UnsubscribeEmailWithToken`: GenericSuccessBoolResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UnsubscribeEmailWithToken`: %v\n", resp)
@@ -2689,8 +2811,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    tokenId := "tokenId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
     updateApiKeyRequest := *onesignal.NewUpdateApiKeyRequest() // UpdateApiKeyRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -2703,6 +2825,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateApiKey`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateApiKey`: %v\n", resp)
@@ -2768,7 +2893,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | An app id
+    appId := "00000000-0000-0000-0000-000000000000" // string | An app id
     app := *onesignal.NewApp() // App | 
 
     configuration := onesignal.NewConfiguration()
@@ -2781,6 +2906,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateApp`: App
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateApp`: %v\n", resp)
@@ -2844,8 +2972,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    activityId := "activityId_example" // string | Live Activity record ID
+    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    activityId := "12345" // string | Live Activity record ID
     updateLiveActivityRequest := *onesignal.NewUpdateLiveActivityRequest("Name_example", "Event_example", map[string]interface{}(123)) // UpdateLiveActivityRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -2858,6 +2986,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateLiveActivity`: UpdateLiveActivitySuccessResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateLiveActivity`: %v\n", resp)
@@ -2923,8 +3054,8 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    subscriptionId := "subscriptionId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -2937,6 +3068,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
 }
 ```
@@ -3000,9 +3134,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | Your OneSignal App ID in UUID v4 format.
-    tokenType := "tokenType_example" // string | The type of token to use when looking up the subscription. See Subscription Types.
-    token := "token_example" // string | The value of the token to lookup by (e.g., email address, phone number).
+    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    tokenType := "Email" // string | The type of token to use when looking up the subscription. See Subscription Types.
+    token := "user@example.com" // string | The value of the token to lookup by (e.g., email address, phone number).
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
 
     configuration := onesignal.NewConfiguration()
@@ -3015,6 +3149,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscriptionByToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateSubscriptionByToken`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateSubscriptionByToken`: %v\n", resp)
@@ -3082,8 +3219,8 @@ import (
 )
 
 func main() {
-    templateId := "templateId_example" // string | 
-    appId := "appId_example" // string | 
+    templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
     updateTemplateRequest := *onesignal.NewUpdateTemplateRequest() // UpdateTemplateRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -3096,6 +3233,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateTemplate`: TemplateResource
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateTemplate`: %v\n", resp)
@@ -3160,9 +3300,9 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
-    aliasLabel := "aliasLabel_example" // string | 
-    aliasId := "aliasId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    aliasLabel := "external_id" // string | 
+    aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     updateUserRequest := *onesignal.NewUpdateUserRequest() // UpdateUserRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -3175,6 +3315,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `UpdateUser`: PropertiesBody
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateUser`: %v\n", resp)
@@ -3242,7 +3385,7 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3254,6 +3397,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewApiKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `ViewApiKeys`: ApiKeyTokensListResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ViewApiKeys`: %v\n", resp)
@@ -3316,8 +3462,8 @@ import (
 )
 
 func main() {
-    templateId := "templateId_example" // string | 
-    appId := "appId_example" // string | 
+    templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
+    appId := "00000000-0000-0000-0000-000000000000" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3329,6 +3475,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `ViewTemplate`: TemplateResource
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ViewTemplate`: %v\n", resp)
@@ -3392,10 +3541,10 @@ import (
 )
 
 func main() {
-    appId := "appId_example" // string | Your OneSignal App ID in UUID v4 format.
-    limit := int32(56) // int32 | Maximum number of templates. Default and max is 50. (optional) (default to 50)
-    offset := int32(56) // int32 | Pagination offset. (optional) (default to 0)
-    channel := "channel_example" // string | Filter by delivery channel. (optional)
+    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    limit := int32(10) // int32 | Maximum number of templates. Default and max is 50. (optional) (default to 50)
+    offset := int32(0) // int32 | Pagination offset. (optional) (default to 0)
+    channel := "push" // string | Filter by delivery channel. (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3407,6 +3556,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplates``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
+        }
     }
     // response from `ViewTemplates`: TemplatesListResponse
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ViewTemplates`: %v\n", resp)


### PR DESCRIPTION
## Release v5.6.0

### 🐛 Bug Fixes
- fix: correct update_subscription_by_token examples and gate C# enum precedence on missing spec example
- fix: address followup snippet-dep bugs (rust E0432, csharp missing System, go uuid hint)

### 📚 Docs
- docs: enrich spec with example: values on path/query params
- docs: add idiomatic error-handling stubs to DefaultApi.md examples
- docs: fix Go type-assertion to pointer type for GenericOpenAPIError
- docs: demonstrate polymorphic response handling for POST /notifications
- docs: fix polymorphic createNotification example correctness across SDKs
- docs: demonstrate idempotency_key on POST /notifications hero example

---
_Generated from [OneSignal/api-client-libraries@3b35d43...4683f25](https://github.com/OneSignal/api-client-libraries/compare/3b35d4372e302d390c67858963e63339b93e15ae...4683f250eaa132250e41a5ac1f9c123598e9b0bd)._