### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-- API version: 5.6.0
-- Package version: 5.6.0
+- API version: 5.7.0
+- Package version: 5.7.0
 
 ## Installation
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,7 +8,7 @@ info:
     customer engagement strategies. Learn more at onesignal.com
   termsOfService: https://onesignal.com/tos
   title: OneSignal
-  version: 5.6.0
+  version: 5.7.0
 servers:
 - url: https://api.onesignal.com
 paths:

--- a/api_default.go
+++ b/api_default.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -42,7 +43,7 @@ var (
 	xmlCheck  = regexp.MustCompile(`(?i:(?:application|text)/xml)`)
 )
 
-// APIClient manages communication with the OneSignal API v5.6.0
+// APIClient manages communication with the OneSignal API v5.7.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration
@@ -324,7 +325,7 @@ func (c *APIClient) prepareRequest(
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 
     // Add the SDK version to OS-Usage header for telemetry
-    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.6.0")
+    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.7.0")
 
 	if ctx != nil {
 		// add context to the request
@@ -566,4 +567,82 @@ func (e GenericOpenAPIError) Body() []byte {
 // Model returns the unpacked model of the error
 func (e GenericOpenAPIError) Model() interface{} {
 	return e.model
+}
+
+// ErrorMessages returns the error messages carried by the response body,
+// normalized to a flat string slice regardless of which envelope shape the API
+// returned (`{"errors": "..."}`, `{"errors": ["..."]}`,
+// `{"errors": [{"code": ..., "title": ...}]}`, or an object map such as
+// `{"errors": {"invalid_aliases": {...}}}`, surfaced as `"<key>: <value>"`
+// entries). It returns an empty slice when the body is not a recognizable error
+// envelope. The raw body remains available via Body().
+func (e GenericOpenAPIError) ErrorMessages() []string {
+	messages := []string{}
+	if len(e.body) == 0 {
+		return messages
+	}
+
+	var envelope struct {
+		Errors json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(e.body, &envelope); err != nil || len(envelope.Errors) == 0 {
+		return messages
+	}
+	if string(envelope.Errors) == "null" {
+		return messages
+	}
+
+	var asString string
+	if err := json.Unmarshal(envelope.Errors, &asString); err == nil {
+		return []string{asString}
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(envelope.Errors, &items); err == nil {
+		for _, item := range items {
+			if string(item) == "null" {
+				continue
+			}
+			var itemString string
+			if err := json.Unmarshal(item, &itemString); err == nil {
+				messages = append(messages, itemString)
+				continue
+			}
+			var itemObject struct {
+				Code  interface{} `json:"code"`
+				Title interface{} `json:"title"`
+			}
+			if err := json.Unmarshal(item, &itemObject); err != nil {
+				continue
+			}
+			if title, ok := itemObject.Title.(string); ok && title != "" {
+				messages = append(messages, title)
+			} else if itemObject.Code != nil {
+				messages = append(messages, fmt.Sprintf("%v", itemObject.Code))
+			}
+		}
+		return messages
+	}
+
+	// Object-shaped envelopes (e.g. {"invalid_aliases": {...}}) carry data under
+	// arbitrary keys; surface each so it isn't silently dropped. Map iteration
+	// order is unspecified, so sort for deterministic output.
+	var asObject map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Errors, &asObject); err == nil {
+		for key, value := range asObject {
+			var valueString string
+			if err := json.Unmarshal(value, &valueString); err == nil {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, valueString))
+				continue
+			}
+			var compact bytes.Buffer
+			if err := json.Compact(&compact, value); err == nil {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, compact.String()))
+			} else {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, string(value)))
+			}
+		}
+		sort.Strings(messages)
+	}
+	return messages
 }

--- a/client_errors_test.go
+++ b/client_errors_test.go
@@ -1,0 +1,68 @@
+package onesignal
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestErrorMessagesNormalizesEnvelopeShapes(t *testing.T) {
+	newErr := func(body string) GenericOpenAPIError {
+		return GenericOpenAPIError{body: []byte(body)}
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"scalar", `{"errors": "Invalid app_id"}`, []string{"Invalid app_id"}},
+		{"array of strings", `{"errors": ["All included players are not subscribed"]}`, []string{"All included players are not subscribed"}},
+		{"array of objects", `{"errors": [{"code": "conflict", "title": "Conflicting aliases"}, {"code": "no_title"}]}`, []string{"Conflicting aliases", "no_title"}},
+		{"no errors field", `{"success": false}`, []string{}},
+		{"unparseable", "not json at all", []string{}},
+		{"null errors", `{"errors": null}`, []string{}},
+		{"array with null", `{"errors": [null]}`, []string{}},
+		{"mixed array", `{"errors": ["str1", {"code": "x", "title": "y"}, "str2"]}`, []string{"str1", "y", "str2"}},
+		{"non-string title", `{"errors": [{"code": "c1", "title": "good"}, {"code": "c2", "title": 42}, {"code": "c3", "title": "later"}]}`, []string{"good", "c2", "later"}},
+		{"empty title falls back to code", `{"errors": [{"title": "", "code": "C1"}]}`, []string{"C1"}},
+		{"object map surfaces keys", `{"errors": {"invalid_aliases": {"external_id": ["111"]}}}`, []string{`invalid_aliases: {"external_id":["111"]}`}},
+		{"object map sorts multiple keys", `{"errors": {"invalid_player_ids": ["pid"], "invalid_aliases": {"external_id": ["111"]}}}`, []string{`invalid_aliases: {"external_id":["111"]}`, `invalid_player_ids: ["pid"]`}},
+		{"object map string value", `{"errors": {"detail": "boom"}}`, []string{"detail: boom"}},
+	}
+
+	for _, tc := range cases {
+		if got := newErr(tc.body).ErrorMessages(); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: ErrorMessages() = %#v, want %#v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The generated OneSignalErrors catalog exposes stable API sentinel strings and
+// pairs with GenericOpenAPIError.ErrorMessages() for membership checks. Pure
+// offline assertions (no network), so this runs without API credentials.
+func TestOneSignalErrorsCatalog(t *testing.T) {
+	if NO_SUBSCRIBERS != "All included players are not subscribed" {
+		t.Errorf("NO_SUBSCRIBERS = %q", NO_SUBSCRIBERS)
+	}
+	if SERVICE_UNAVAILABLE != "Service temporarily unavailable" {
+		t.Errorf("SERVICE_UNAVAILABLE = %q", SERVICE_UNAVAILABLE)
+	}
+	// Pin the auth string verbatim, including the intentional double space after
+	// "denied." — a whitespace-normalizing edit would silently break matching.
+	const wantInvalidKey = "Access denied.  Please include an 'Authorization: ...' header with a valid API key (https://documentation.onesignal.com/docs/en/keys-and-ids#api-keys)."
+	if INVALID_API_KEY != wantInvalidKey {
+		t.Errorf("INVALID_API_KEY = %q, want %q", INVALID_API_KEY, wantInvalidKey)
+	}
+
+	err := GenericOpenAPIError{body: []byte(`{"errors": ["All included players are not subscribed"]}`)}
+	found := false
+	for _, m := range err.ErrorMessages() {
+		if m == NO_SUBSCRIBERS {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ErrorMessages() should contain NO_SUBSCRIBERS")
+	}
+}

--- a/configuration.go
+++ b/configuration.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 
@@ -105,7 +105,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/5.6.0/go",
+		UserAgent:        "OpenAPI-Generator/5.7.0/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -64,7 +64,7 @@ Every operation requires either a **REST API Key** (App-scoped, used by ~77% of 
 
 ### Error handling
 
-When a request fails, the call returns a non-nil `err`. The raw `*http.Response` (the second return value, conventionally `r`) is non-nil only when the failure occurred AFTER the HTTP round-trip completed — for pre-roundtrip failures (URL build, missing required parameter, prepareRequest error, transport errors like DNS/timeout/TLS) `r` is `nil`. Always nil-check `r` before reading `r.StatusCode` (int). For the parsed error body, type-assert `err` to `*onesignal.GenericOpenAPIError` (pointer — the SDK constructs every error as `&GenericOpenAPIError{...}`, so a value-type assertion silently returns `ok=false`) and call `apiErr.Body()` (returns `[]byte`, the raw JSON envelope). Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes.
+When a request fails, the call returns a non-nil `err`. The raw `*http.Response` (the second return value, conventionally `r`) is non-nil only when the failure occurred AFTER the HTTP round-trip completed — for pre-roundtrip failures (URL build, missing required parameter, prepareRequest error, transport errors like DNS/timeout/TLS) `r` is `nil`. Always nil-check `r` before reading `r.StatusCode` (int). For the parsed error body, type-assert `err` to `*onesignal.GenericOpenAPIError` (pointer — the SDK constructs every error as `&GenericOpenAPIError{...}`, so a value-type assertion silently returns `ok=false`) and call `apiErr.Body()` (returns `[]byte`, the raw JSON envelope). Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes. The `apiErr.ErrorMessages()` method does this for you, normalizing every shape to a flat `[]string` (empty when the body carries no `errors`).
 
 ### Polymorphic 200 from POST /notifications
 
@@ -119,6 +119,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CancelNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -199,6 +202,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CopyTemplateToApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -281,6 +287,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -365,6 +374,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAliasBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -446,6 +458,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -524,6 +539,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -598,6 +616,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateCustomEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -773,6 +794,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -854,6 +878,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -936,6 +963,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1010,6 +1040,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1091,6 +1124,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1175,6 +1211,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1255,6 +1294,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1335,6 +1377,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1413,6 +1458,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1493,6 +1541,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1573,6 +1624,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1652,6 +1706,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportSubscriptions``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1732,6 +1789,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliases``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1814,6 +1874,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliasesBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1893,6 +1956,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1969,6 +2035,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApps``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2039,6 +2108,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2118,6 +2190,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotificationHistory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2199,6 +2274,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotifications``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2280,6 +2358,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetOutcomes``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2364,6 +2445,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetSegments``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2445,6 +2529,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2527,6 +2614,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.RotateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2608,6 +2698,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.StartLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2690,6 +2783,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.TransferSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2772,6 +2868,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UnsubscribeEmailWithToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2854,6 +2953,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2935,6 +3037,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3015,6 +3120,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3097,6 +3205,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3178,6 +3289,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscriptionByToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3262,6 +3376,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3344,6 +3461,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3426,6 +3546,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewApiKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3504,6 +3627,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3585,6 +3711,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplates``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }

--- a/error_catalog.go
+++ b/error_catalog.go
@@ -1,0 +1,24 @@
+// Generated from inputs/api/error-catalog.json. Do not edit by hand.
+
+package onesignal
+
+// Sentinel error message strings the OneSignal API can return. Each
+// constant equals the literal message the server emits, so you can test
+// membership against GenericOpenAPIError.ErrorMessages() (e.g.
+// NO_TARGETING_SPECIFIED).
+//
+// Note: 200-status sentinels such as NO_SUBSCRIBERS arrive on a successful
+// response, not via the exception accessor — read the response's errors
+// field for those.
+const (
+	// HTTP 403 | retryable: no | emitted by: any API-key-authenticated endpoint (REST or Organization key) | note: Generic auth-failure message the public api.onesignal.com edge returns for any invalid or mismatched key — REST or Organization — so a single sentinel covers both. Supersedes the Rails-monolith INVALID_REST_API_KEY / INVALID_USER_AUTH_KEY strings, which the public host no longer returns verbatim. Note the double space after 'denied.'
+	INVALID_API_KEY = "Access denied.  Please include an 'Authorization: ...' header with a valid API key (https://documentation.onesignal.com/docs/en/keys-and-ids#api-keys)."
+	// HTTP 400, 404 | retryable: no | emitted by: POST /notifications/{id}/history, POST /notifications/{id}/messages, GET /notifications/{id} (export) | note: Verified live 2026-06-16: GET /notifications/{bogus-uuid} returns 404 with this exact message.
+	NOTIFICATION_NOT_FOUND = "Notification not found"
+	// HTTP 200 | retryable: no | emitted by: POST /notifications | note: Returned with HTTP 200 OK (id is empty), not an error status. The flagship case for the errorMessages accessor — lets callers distinguish a sent notification from a no-op without parsing the polymorphic 200 body.
+	NO_SUBSCRIBERS = "All included players are not subscribed"
+	// HTTP 400 | retryable: no | emitted by: POST /notifications | note: Verified live 2026-06-16: a no-targeting POST /notifications returns 400 with this exact message.
+	NO_TARGETING_SPECIFIED = "You must include which players, segments, or tags you wish to send this notification to."
+	// HTTP 503 | retryable: yes | emitted by: any endpoint (pgbouncer rejection) | note: Transient DB/pgbouncer failure — the canonical retryable sentinel.
+	SERVICE_UNAVAILABLE = "Service temporarily unavailable"
+)

--- a/model_api_key_token.go
+++ b/model_api_key_token.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_api_key_tokens_list_response.go
+++ b/model_api_key_tokens_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_app.go
+++ b/model_app.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification_all_of_android_background_layout.go
+++ b/model_basic_notification_all_of_android_background_layout.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_button.go
+++ b/model_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_copy_template_request.go
+++ b/model_copy_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_request.go
+++ b/model_create_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_response.go
+++ b/model_create_api_key_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_notification_success_response.go
+++ b/model_create_notification_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_conflict_response.go
+++ b/model_create_segment_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_success_response.go
+++ b/model_create_segment_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_template_request.go
+++ b/model_create_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response.go
+++ b/model_create_user_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_inner.go
+++ b/model_create_user_conflict_response_errors_inner.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_items_meta.go
+++ b/model_create_user_conflict_response_errors_items_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_event.go
+++ b/model_custom_event.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_events_request.go
+++ b/model_custom_events_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_delivery_data.go
+++ b/model_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_events_success_response.go
+++ b/model_export_events_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_request_body.go
+++ b/model_export_subscriptions_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_success_response.go
+++ b/model_export_subscriptions_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter.go
+++ b/model_filter.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter_expression.go
+++ b/model_filter_expression.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_error.go
+++ b/model_generic_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_success_bool_response.go
+++ b/model_generic_success_bool_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_notification_history_request_body.go
+++ b/model_get_notification_history_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_segments_success_response.go
+++ b/model_get_segments_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_language_string_map.go
+++ b/model_language_string_map.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification.go
+++ b/model_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_all_of.go
+++ b/model_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_history_success_response.go
+++ b/model_notification_history_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_slice.go
+++ b/model_notification_slice.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_target.go
+++ b/model_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_with_meta_all_of.go
+++ b/model_notification_with_meta_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_operator.go
+++ b/model_operator.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcome_data.go
+++ b/model_outcome_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcomes_data.go
+++ b/model_outcomes_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data.go
+++ b/model_platform_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_email_all_of.go
+++ b/model_platform_delivery_data_email_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_sms_all_of.go
+++ b/model_platform_delivery_data_sms_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_body.go
+++ b/model_properties_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_deltas.go
+++ b/model_properties_deltas.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_object.go
+++ b/model_properties_object.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_purchase.go
+++ b/model_purchase.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_rate_limit_error.go
+++ b/model_rate_limit_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment.go
+++ b/model_segment.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_data.go
+++ b/model_segment_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_notification_target.go
+++ b/model_segment_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_request.go
+++ b/model_start_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_success_response.go
+++ b/model_start_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription.go
+++ b/model_subscription.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_body.go
+++ b/model_subscription_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_notification_target.go
+++ b/model_subscription_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_template_resource.go
+++ b/model_template_resource.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_templates_list_response.go
+++ b/model_templates_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_transfer_subscription_request_body.go
+++ b/model_transfer_subscription_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_api_key_request.go
+++ b/model_update_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_request.go
+++ b/model_update_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_success_response.go
+++ b/model_update_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_template_request.go
+++ b/model_update_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_user_request.go
+++ b/model_update_user_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user.go
+++ b/model_user.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user_identity_body.go
+++ b/model_user_identity_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_web_button.go
+++ b/model_web_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/response.go
+++ b/response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK

### 🐛 Bug Fixes
- fix: [SDK-4438] return empty from Go ErrorMessages for null envelopes
- fix: [SDK-4438] dispatch Go ErrorMessages array items individually
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel

---
_Generated from [OneSignal/api-client-libraries@e4fc576...576a989](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...576a989ab8013109085bfad4011540e50afd7467)._