### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-- API version: 5.6.0
-- Package version: 5.6.0
+- API version: 5.7.0
+- Package version: 5.7.0
 
 ## Installation
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,7 +8,7 @@ info:
     customer engagement strategies. Learn more at onesignal.com
   termsOfService: https://onesignal.com/tos
   title: OneSignal
-  version: 5.6.0
+  version: 5.7.0
 servers:
 - url: https://api.onesignal.com
 paths:
@@ -881,6 +881,7 @@ paths:
           description: Rate Limit Exceeded
       security:
       - rest_api_key: []
+      x-onesignal-create-user-conflict-example: true
   /apps/{app_id}/users/by/{alias_label}/{alias_id}:
     delete:
       description: "Removes the User identified by (:alias_label, :alias_id), and\

--- a/api_default.go
+++ b/api_default.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -42,7 +43,7 @@ var (
 	xmlCheck  = regexp.MustCompile(`(?i:(?:application|text)/xml)`)
 )
 
-// APIClient manages communication with the OneSignal API v5.6.0
+// APIClient manages communication with the OneSignal API v5.7.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration
@@ -324,7 +325,7 @@ func (c *APIClient) prepareRequest(
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 
     // Add the SDK version to OS-Usage header for telemetry
-    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.6.0")
+    localVarRequest.Header.Add("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-go, version=5.7.0")
 
 	if ctx != nil {
 		// add context to the request
@@ -566,4 +567,82 @@ func (e GenericOpenAPIError) Body() []byte {
 // Model returns the unpacked model of the error
 func (e GenericOpenAPIError) Model() interface{} {
 	return e.model
+}
+
+// ErrorMessages returns the error messages carried by the response body,
+// normalized to a flat string slice regardless of which envelope shape the API
+// returned (`{"errors": "..."}`, `{"errors": ["..."]}`,
+// `{"errors": [{"code": ..., "title": ...}]}`, or an object map such as
+// `{"errors": {"invalid_aliases": {...}}}`, surfaced as `"<key>: <value>"`
+// entries). It returns an empty slice when the body is not a recognizable error
+// envelope. The raw body remains available via Body().
+func (e GenericOpenAPIError) ErrorMessages() []string {
+	messages := []string{}
+	if len(e.body) == 0 {
+		return messages
+	}
+
+	var envelope struct {
+		Errors json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(e.body, &envelope); err != nil || len(envelope.Errors) == 0 {
+		return messages
+	}
+	if string(envelope.Errors) == "null" {
+		return messages
+	}
+
+	var asString string
+	if err := json.Unmarshal(envelope.Errors, &asString); err == nil {
+		return []string{asString}
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(envelope.Errors, &items); err == nil {
+		for _, item := range items {
+			if string(item) == "null" {
+				continue
+			}
+			var itemString string
+			if err := json.Unmarshal(item, &itemString); err == nil {
+				messages = append(messages, itemString)
+				continue
+			}
+			var itemObject struct {
+				Code  interface{} `json:"code"`
+				Title interface{} `json:"title"`
+			}
+			if err := json.Unmarshal(item, &itemObject); err != nil {
+				continue
+			}
+			if title, ok := itemObject.Title.(string); ok && title != "" {
+				messages = append(messages, title)
+			} else if itemObject.Code != nil {
+				messages = append(messages, fmt.Sprintf("%v", itemObject.Code))
+			}
+		}
+		return messages
+	}
+
+	// Object-shaped envelopes (e.g. {"invalid_aliases": {...}}) carry data under
+	// arbitrary keys; surface each so it isn't silently dropped. Map iteration
+	// order is unspecified, so sort for deterministic output.
+	var asObject map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Errors, &asObject); err == nil {
+		for key, value := range asObject {
+			var valueString string
+			if err := json.Unmarshal(value, &valueString); err == nil {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, valueString))
+				continue
+			}
+			var compact bytes.Buffer
+			if err := json.Compact(&compact, value); err == nil {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, compact.String()))
+			} else {
+				messages = append(messages, fmt.Sprintf("%s: %s", key, string(value)))
+			}
+		}
+		sort.Strings(messages)
+	}
+	return messages
 }

--- a/client_errors_test.go
+++ b/client_errors_test.go
@@ -1,0 +1,68 @@
+package onesignal
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestErrorMessagesNormalizesEnvelopeShapes(t *testing.T) {
+	newErr := func(body string) GenericOpenAPIError {
+		return GenericOpenAPIError{body: []byte(body)}
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"scalar", `{"errors": "Invalid app_id"}`, []string{"Invalid app_id"}},
+		{"array of strings", `{"errors": ["All included players are not subscribed"]}`, []string{"All included players are not subscribed"}},
+		{"array of objects", `{"errors": [{"code": "conflict", "title": "Conflicting aliases"}, {"code": "no_title"}]}`, []string{"Conflicting aliases", "no_title"}},
+		{"no errors field", `{"success": false}`, []string{}},
+		{"unparseable", "not json at all", []string{}},
+		{"null errors", `{"errors": null}`, []string{}},
+		{"array with null", `{"errors": [null]}`, []string{}},
+		{"mixed array", `{"errors": ["str1", {"code": "x", "title": "y"}, "str2"]}`, []string{"str1", "y", "str2"}},
+		{"non-string title", `{"errors": [{"code": "c1", "title": "good"}, {"code": "c2", "title": 42}, {"code": "c3", "title": "later"}]}`, []string{"good", "c2", "later"}},
+		{"empty title falls back to code", `{"errors": [{"title": "", "code": "C1"}]}`, []string{"C1"}},
+		{"object map surfaces keys", `{"errors": {"invalid_aliases": {"external_id": ["111"]}}}`, []string{`invalid_aliases: {"external_id":["111"]}`}},
+		{"object map sorts multiple keys", `{"errors": {"invalid_player_ids": ["pid"], "invalid_aliases": {"external_id": ["111"]}}}`, []string{`invalid_aliases: {"external_id":["111"]}`, `invalid_player_ids: ["pid"]`}},
+		{"object map string value", `{"errors": {"detail": "boom"}}`, []string{"detail: boom"}},
+	}
+
+	for _, tc := range cases {
+		if got := newErr(tc.body).ErrorMessages(); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: ErrorMessages() = %#v, want %#v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The generated OneSignalErrors catalog exposes stable API sentinel strings and
+// pairs with GenericOpenAPIError.ErrorMessages() for membership checks. Pure
+// offline assertions (no network), so this runs without API credentials.
+func TestOneSignalErrorsCatalog(t *testing.T) {
+	if NO_SUBSCRIBERS != "All included players are not subscribed" {
+		t.Errorf("NO_SUBSCRIBERS = %q", NO_SUBSCRIBERS)
+	}
+	if SERVICE_UNAVAILABLE != "Service temporarily unavailable" {
+		t.Errorf("SERVICE_UNAVAILABLE = %q", SERVICE_UNAVAILABLE)
+	}
+	// Pin the auth string verbatim, including the intentional double space after
+	// "denied." — a whitespace-normalizing edit would silently break matching.
+	const wantInvalidKey = "Access denied.  Please include an 'Authorization: ...' header with a valid API key (https://documentation.onesignal.com/docs/en/keys-and-ids#api-keys)."
+	if INVALID_API_KEY != wantInvalidKey {
+		t.Errorf("INVALID_API_KEY = %q, want %q", INVALID_API_KEY, wantInvalidKey)
+	}
+
+	err := GenericOpenAPIError{body: []byte(`{"errors": ["All included players are not subscribed"]}`)}
+	found := false
+	for _, m := range err.ErrorMessages() {
+		if m == NO_SUBSCRIBERS {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ErrorMessages() should contain NO_SUBSCRIBERS")
+	}
+}

--- a/configuration.go
+++ b/configuration.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 
@@ -105,7 +105,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/5.6.0/go",
+		UserAgent:        "OpenAPI-Generator/5.7.0/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -62,9 +62,18 @@ Every operation requires either a **REST API Key** (App-scoped, used by ~77% of 
 
 `POST /notifications` accepts a top-level `idempotency_key` (UUIDv4) that the server uses for request dedup within a **30-day window**. Pass a freshly-generated UUID per logical send so that network-level retries are safe. Never reuse a key across distinct sends — the server returns the original response instead of acting on the new payload. The hero `CreateNotification` example below demonstrates the call.
 
+Prefer the bundled `CreateNotificationWithRetry` helper over wiring this up by hand: it generates the key when absent (a caller-provided key is respected), retries 429 / 503 / transport errors with the **same** key (honoring `Retry-After`, exponential backoff otherwise; `MaxRetries` / `BaseDelay` configurable via the options struct), fails fast on other errors, and reports via `WasReplayed` whether the server answered from a previously completed request (`Idempotent-Replayed` response header). It is available as a `DefaultApi` method so the call mirrors `CreateNotification`:
+
+```go
+result, err := apiClient.DefaultApi.CreateNotificationWithRetry(context.Background(), *notification, nil)
+if err == nil {
+    fmt.Printf("%s replayed=%v\n", result.Response.GetId(), result.WasReplayed)
+}
+```
+
 ### Error handling
 
-When a request fails, the call returns a non-nil `err`. The raw `*http.Response` (the second return value, conventionally `r`) is non-nil only when the failure occurred AFTER the HTTP round-trip completed — for pre-roundtrip failures (URL build, missing required parameter, prepareRequest error, transport errors like DNS/timeout/TLS) `r` is `nil`. Always nil-check `r` before reading `r.StatusCode` (int). For the parsed error body, type-assert `err` to `*onesignal.GenericOpenAPIError` (pointer — the SDK constructs every error as `&GenericOpenAPIError{...}`, so a value-type assertion silently returns `ok=false`) and call `apiErr.Body()` (returns `[]byte`, the raw JSON envelope). Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes.
+When a request fails, the call returns a non-nil `err`. The raw `*http.Response` (the second return value, conventionally `r`) is non-nil only when the failure occurred AFTER the HTTP round-trip completed — for pre-roundtrip failures (URL build, missing required parameter, prepareRequest error, transport errors like DNS/timeout/TLS) `r` is `nil`. Always nil-check `r` before reading `r.StatusCode` (int). For the parsed error body, type-assert `err` to `*onesignal.GenericOpenAPIError` (pointer — the SDK constructs every error as `&GenericOpenAPIError{...}`, so a value-type assertion silently returns `ok=false`) and call `apiErr.Body()` (returns `[]byte`, the raw JSON envelope). Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes. The `apiErr.ErrorMessages()` method does this for you, normalizing every shape to a flat `[]string` (empty when the body carries no `errors`). To branch on a specific error without hard-coding message strings, test membership against the generated [`OneSignalErrors`](https://github.com/OneSignal/onesignal-go-api/blob/main/error_catalog.go) catalog — e.g. check whether `apiErr.ErrorMessages()` contains `onesignal.NO_TARGETING_SPECIFIED`.
 
 ### Polymorphic 200 from POST /notifications
 
@@ -119,6 +128,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CancelNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -199,6 +211,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CopyTemplateToApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -281,6 +296,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -365,6 +383,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateAliasBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -446,6 +467,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -524,6 +548,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -598,6 +625,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateCustomEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -707,6 +737,50 @@ func main() {
 }
 ```
 
+#### Using `CreateNotificationWithRetry` (preferred for safe, idempotent retries)
+
+The `CreateNotificationWithRetry` method mirrors `CreateNotification` but generates the `IdempotencyKey` for you, transparently retries transient failures (HTTP 429 / 503 / transport errors) with the **same** key, and reports via `WasReplayed` whether the server answered from a previously-completed request.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+
+    "github.com/OneSignal/onesignal-go-api"
+)
+
+func main() {
+    configuration := onesignal.NewConfiguration()
+    apiClient := onesignal.NewAPIClient(configuration)
+
+    restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY")
+
+    notification := onesignal.NewNotification("YOUR_APP_ID")
+    contents := onesignal.NewLanguageStringMap()
+    contents.SetEn("Hello from OneSignal!")
+    notification.SetContents(*contents)
+    notification.SetIncludeAliases(map[string][]string{"external_id": {"YOUR_USER_EXTERNAL_ID"}})
+    notification.SetTargetChannel("push")
+    // No idempotency key set: the helper generates a UUIDv4 and reuses it across retries.
+
+    // opts is optional — pass nil for defaults (3 retries, 1s backoff base).
+    opts := &onesignal.CreateNotificationWithRetryOptions{MaxRetries: 5}
+    result, err := apiClient.DefaultApi.CreateNotificationWithRetry(restAuth, *notification, opts)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "CreateNotificationWithRetry failed: %v\n", err)
+        return
+    }
+    if result.WasReplayed {
+        fmt.Fprintf(os.Stdout, "Server replayed a prior send (no duplicate): %s\n", result.Response.GetId())
+    } else {
+        fmt.Fprintf(os.Stdout, "Notification created: %s\n", result.Response.GetId())
+    }
+}
+```
+
 ### Path Parameters
 
 
@@ -773,6 +847,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -854,6 +931,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -936,6 +1016,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1010,11 +1093,28 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
     // response from `CreateUser`: User
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateUser`: %v\n", resp)
+}
+```
+
+### Reading the 409 conflict metadata
+
+A `409` from this endpoint deserializes to `CreateUserConflictResponse`. `ErrorMessages()` flattens each error to its `title`/`code` and omits the structured `meta` object (currently `conflicting_aliases`); read it from the typed model via `Model()`:
+
+```go
+if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+    if conflict, ok := apiErr.Model().(onesignal.CreateUserConflictResponse); ok {
+        for _, e := range conflict.GetErrors() {
+            fmt.Println(e.GetTitle(), e.GetMeta().GetConflictingAliases())
+        }
+    }
 }
 ```
 
@@ -1091,6 +1191,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteAlias``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1175,6 +1278,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1255,6 +1361,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSegment``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1335,6 +1444,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1413,6 +1525,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1493,6 +1608,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1573,6 +1691,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportEvents``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1652,6 +1773,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ExportSubscriptions``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1732,6 +1856,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliases``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1814,6 +1941,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetAliasesBySubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1893,6 +2023,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -1969,6 +2102,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetApps``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2039,6 +2175,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotification``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2118,6 +2257,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotificationHistory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2199,6 +2341,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotifications``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2280,6 +2425,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetOutcomes``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2364,6 +2512,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetSegments``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2445,6 +2596,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2527,6 +2681,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.RotateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2608,6 +2765,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.StartLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2690,6 +2850,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.TransferSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2772,6 +2935,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UnsubscribeEmailWithToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2854,6 +3020,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApiKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -2935,6 +3104,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateApp``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3015,6 +3187,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateLiveActivity``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3097,6 +3272,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscription``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3178,6 +3356,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscriptionByToken``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3262,6 +3443,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3344,6 +3528,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3426,6 +3613,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewApiKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3504,6 +3694,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplate``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }
@@ -3585,6 +3778,9 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ViewTemplates``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
+            // ErrorMessages() flattens any error-envelope shape to a []string;
+            // the raw body remains on Body().
+            fmt.Fprintf(os.Stderr, "Error Messages: %v\n", apiErr.ErrorMessages())
             fmt.Fprintf(os.Stderr, "Response Body: %s\n", apiErr.Body())
         }
     }

--- a/error_catalog.go
+++ b/error_catalog.go
@@ -1,0 +1,24 @@
+// Generated from inputs/api/error-catalog.json. Do not edit by hand.
+
+package onesignal
+
+// Sentinel error message strings the OneSignal API can return. Each
+// constant equals the literal message the server emits, so you can test
+// membership against GenericOpenAPIError.ErrorMessages() (e.g.
+// NO_TARGETING_SPECIFIED).
+//
+// Note: 200-status sentinels such as NO_SUBSCRIBERS arrive on a successful
+// response, not via the exception accessor — read the response's errors
+// field for those.
+const (
+	// HTTP 403 | retryable: no | emitted by: any API-key-authenticated endpoint (REST or Organization key) | note: Generic auth-failure message the public api.onesignal.com edge returns for any invalid or mismatched key — REST or Organization — so a single sentinel covers both. Supersedes the Rails-monolith INVALID_REST_API_KEY / INVALID_USER_AUTH_KEY strings, which the public host no longer returns verbatim. Note the double space after 'denied.'
+	INVALID_API_KEY = "Access denied.  Please include an 'Authorization: ...' header with a valid API key (https://documentation.onesignal.com/docs/en/keys-and-ids#api-keys)."
+	// HTTP 400, 404 | retryable: no | emitted by: POST /notifications/{id}/history, POST /notifications/{id}/messages, GET /notifications/{id} (export) | note: Verified live 2026-06-16: GET /notifications/{bogus-uuid} returns 404 with this exact message.
+	NOTIFICATION_NOT_FOUND = "Notification not found"
+	// HTTP 200 | retryable: no | emitted by: POST /notifications | note: Returned with HTTP 200 OK (id is empty), not an error status. The flagship case for the errorMessages accessor — lets callers distinguish a sent notification from a no-op without parsing the polymorphic 200 body.
+	NO_SUBSCRIBERS = "All included players are not subscribed"
+	// HTTP 400 | retryable: no | emitted by: POST /notifications | note: Verified live 2026-06-16: a no-targeting POST /notifications returns 400 with this exact message.
+	NO_TARGETING_SPECIFIED = "You must include which players, segments, or tags you wish to send this notification to."
+	// HTTP 503 | retryable: yes | emitted by: any endpoint (pgbouncer rejection) | note: Transient DB/pgbouncer failure — the canonical retryable sentinel.
+	SERVICE_UNAVAILABLE = "Service temporarily unavailable"
+)

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,128 @@
+package onesignal
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CreateNotificationWithRetryOptions configures CreateNotificationWithRetry.
+// Zero or negative values fall back to the defaults.
+type CreateNotificationWithRetryOptions struct {
+	// MaxRetries is the number of retries after the initial attempt. Default 3.
+	MaxRetries int
+	// BaseDelay is the exponential-backoff base used when the response carries
+	// no Retry-After header. Clamped to [1s, 60s]. Default 1s.
+	BaseDelay time.Duration
+}
+
+const (
+	minBaseDelay = time.Second
+	maxBaseDelay = 60 * time.Second
+)
+
+// CreateNotificationWithRetryResult carries the create response plus whether
+// the server replayed a previously completed request (Idempotent-Replayed
+// response header).
+type CreateNotificationWithRetryResult struct {
+	Response    *CreateNotificationSuccessResponse
+	WasReplayed bool
+}
+
+// CreateNotificationWithRetry creates a notification with safe, idempotent
+// retries. It ensures notification.IdempotencyKey is set (generating a UUIDv4
+// when absent) so the server can deduplicate, then calls CreateNotification.
+// Transient failures (HTTP 429, HTTP 503, or transport-level errors) are
+// retried with the SAME idempotency key, honoring the Retry-After response
+// header when present and falling back to exponential backoff
+// (BaseDelay * 2^attempt) otherwise. Other errors are returned immediately.
+func CreateNotificationWithRetry(ctx context.Context, client *APIClient, notification Notification, opts *CreateNotificationWithRetryOptions) (*CreateNotificationWithRetryResult, error) {
+	maxRetries := 3
+	baseDelay := time.Second
+	if opts != nil {
+		if opts.MaxRetries > 0 {
+			maxRetries = opts.MaxRetries
+		}
+		if opts.BaseDelay > 0 {
+			baseDelay = opts.BaseDelay
+		}
+	}
+	// Clamp the backoff base so a stray value can neither hammer the API
+	// (too small) nor stall the caller for an unbounded stretch (too large).
+	if baseDelay < minBaseDelay {
+		baseDelay = minBaseDelay
+	} else if baseDelay > maxBaseDelay {
+		baseDelay = maxBaseDelay
+	}
+
+	if notification.IdempotencyKey.Get() == nil || *notification.IdempotencyKey.Get() == "" {
+		key, err := newUUIDv4()
+		if err != nil {
+			return nil, err
+		}
+		notification.SetIdempotencyKey(key)
+	}
+
+	for attempt := 0; ; attempt++ {
+		resp, httpResp, err := client.DefaultApi.CreateNotification(ctx).Notification(notification).Execute()
+		if err == nil {
+			return &CreateNotificationWithRetryResult{
+				Response:    resp,
+				WasReplayed: isReplayed(httpResp),
+			}, nil
+		}
+
+		// A nil *http.Response means the request never completed (timeout,
+		// connection failure) — transient by definition.
+		retryable := httpResp == nil || httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode == http.StatusServiceUnavailable
+		if !retryable || attempt >= maxRetries {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(retryDelay(httpResp, attempt, baseDelay)):
+		}
+	}
+}
+
+// CreateNotificationWithRetry surfaces the idempotent-retry helper as a
+// DefaultApiService method so the call mirrors CreateNotification. It
+// delegates to the package-level CreateNotificationWithRetry (single source of
+// truth), reusing this service's API client.
+func (a *DefaultApiService) CreateNotificationWithRetry(ctx context.Context, notification Notification, opts *CreateNotificationWithRetryOptions) (*CreateNotificationWithRetryResult, error) {
+	return CreateNotificationWithRetry(ctx, a.client, notification, opts)
+}
+
+func isReplayed(httpResp *http.Response) bool {
+	if httpResp == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(httpResp.Header.Get("Idempotent-Replayed")), "true")
+}
+
+func retryDelay(httpResp *http.Response, attempt int, baseDelay time.Duration) time.Duration {
+	if httpResp != nil {
+		if retryAfter := strings.TrimSpace(httpResp.Header.Get("Retry-After")); retryAfter != "" {
+			if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds >= 0 {
+				return time.Duration(seconds) * time.Second
+			}
+		}
+	}
+	return baseDelay * (1 << uint(attempt))
+}
+
+func newUUIDv4() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/model_api_key_token.go
+++ b/model_api_key_token.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_api_key_tokens_list_response.go
+++ b/model_api_key_tokens_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_app.go
+++ b/model_app.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_basic_notification_all_of_android_background_layout.go
+++ b/model_basic_notification_all_of_android_background_layout.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_button.go
+++ b/model_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_copy_template_request.go
+++ b/model_copy_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_request.go
+++ b/model_create_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_api_key_response.go
+++ b/model_create_api_key_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_notification_success_response.go
+++ b/model_create_notification_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_conflict_response.go
+++ b/model_create_segment_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_segment_success_response.go
+++ b/model_create_segment_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_template_request.go
+++ b/model_create_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response.go
+++ b/model_create_user_conflict_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_inner.go
+++ b/model_create_user_conflict_response_errors_inner.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_create_user_conflict_response_errors_items_meta.go
+++ b/model_create_user_conflict_response_errors_items_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_event.go
+++ b/model_custom_event.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_custom_events_request.go
+++ b/model_custom_events_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_delivery_data.go
+++ b/model_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_events_success_response.go
+++ b/model_export_events_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_request_body.go
+++ b/model_export_subscriptions_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_export_subscriptions_success_response.go
+++ b/model_export_subscriptions_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter.go
+++ b/model_filter.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_filter_expression.go
+++ b/model_filter_expression.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_error.go
+++ b/model_generic_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_generic_success_bool_response.go
+++ b/model_generic_success_bool_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_notification_history_request_body.go
+++ b/model_get_notification_history_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_get_segments_success_response.go
+++ b/model_get_segments_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_language_string_map.go
+++ b/model_language_string_map.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification.go
+++ b/model_notification.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_all_of.go
+++ b/model_notification_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_history_success_response.go
+++ b/model_notification_history_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_slice.go
+++ b/model_notification_slice.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_target.go
+++ b/model_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_notification_with_meta_all_of.go
+++ b/model_notification_with_meta_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_operator.go
+++ b/model_operator.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcome_data.go
+++ b/model_outcome_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_outcomes_data.go
+++ b/model_outcomes_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data.go
+++ b/model_platform_delivery_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_email_all_of.go
+++ b/model_platform_delivery_data_email_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_platform_delivery_data_sms_all_of.go
+++ b/model_platform_delivery_data_sms_all_of.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_body.go
+++ b/model_properties_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_deltas.go
+++ b/model_properties_deltas.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_properties_object.go
+++ b/model_properties_object.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_purchase.go
+++ b/model_purchase.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_rate_limit_error.go
+++ b/model_rate_limit_error.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment.go
+++ b/model_segment.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_data.go
+++ b/model_segment_data.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_segment_notification_target.go
+++ b/model_segment_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_request.go
+++ b/model_start_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_start_live_activity_success_response.go
+++ b/model_start_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription.go
+++ b/model_subscription.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_body.go
+++ b/model_subscription_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_subscription_notification_target.go
+++ b/model_subscription_notification_target.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_template_resource.go
+++ b/model_template_resource.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_templates_list_response.go
+++ b/model_templates_list_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_transfer_subscription_request_body.go
+++ b/model_transfer_subscription_request_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_api_key_request.go
+++ b/model_update_api_key_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_request.go
+++ b/model_update_live_activity_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_live_activity_success_response.go
+++ b/model_update_live_activity_success_response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_template_request.go
+++ b/model_update_template_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_update_user_request.go
+++ b/model_update_user_request.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user.go
+++ b/model_user.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_user_identity_body.go
+++ b/model_user_identity_body.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/model_web_button.go
+++ b/model_web_button.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/response.go
+++ b/response.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,7 @@ OneSignal
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
-API version: 5.6.0
+API version: 5.7.0
 Contact: devrel@onesignal.com
 */
 


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4438] add typed error-messages accessor to ApiException
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification

### 📚 Docs
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...06c5b0f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...06c5b0ffeb52f85914a6dd8f14ad4d6cdf81c176)._
