### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3619,9 +3619,12 @@ components:
         errors: ""
       properties:
         id:
-          description: Notification identifier when the request created a notification.
-            An empty string means no notification was created; read `errors` for details
-            (HTTP may still be 200).
+          description: "Notification identifier when the request created a notification.\
+            \ An empty string means no notification was created; read `errors` for\
+            \ details (HTTP may still be 200). All OneSignal server SDKs expose message-sent\
+            \ / message-not-sent narrowing helpers (named idiomatically per language\
+            \ — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer\
+            \ them over comparing `id` directly."
           type: string
         external_id:
           description: Optional correlation / idempotency-related value from the API

--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | Pointer to **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional] 
+**Id** | Pointer to **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional] 
 **ExternalId** | Pointer to **NullableString** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional] 
 **Errors** | Pointer to **interface{}** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 

--- a/helpers.go
+++ b/helpers.go
@@ -117,6 +117,28 @@ func retryDelay(httpResp *http.Response, attempt int, baseDelay time.Duration) t
 	return baseDelay * (1 << uint(attempt))
 }
 
+// MessageSent and MessageNotSent name the two branches of a POST /notifications
+// 200 response, which share the CreateNotificationSuccessResponse shape:
+// MessageSent is the branch where a notification was created (non-empty Id);
+// MessageNotSent is the branch where none was (empty Id, with Errors carrying
+// the reason). Use the IsMessageSent / IsMessageNotSent guards to discriminate.
+type MessageSent = CreateNotificationSuccessResponse
+type MessageNotSent = CreateNotificationSuccessResponse
+
+// IsMessageSent reports whether a POST /notifications 200 response is the
+// "message sent" branch — a notification was created (Id is a non-empty
+// string). Prefer this over inspecting Id directly.
+func IsMessageSent(response *CreateNotificationSuccessResponse) bool {
+	return response != nil && response.GetId() != ""
+}
+
+// IsMessageNotSent reports whether a POST /notifications 200 response is the
+// "message not sent" branch — no notification was created (Id is absent or
+// empty); inspect Errors for why.
+func IsMessageNotSent(response *CreateNotificationSuccessResponse) bool {
+	return !IsMessageSent(response)
+}
+
 func newUUIDv4() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/model_create_notification_success_response.go
+++ b/model_create_notification_success_response.go
@@ -17,7 +17,7 @@ import (
 
 // CreateNotificationSuccessResponse struct for CreateNotificationSuccessResponse
 type CreateNotificationSuccessResponse struct {
-	// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+	// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
 	Id *string `json:"id,omitempty"`
 	// Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).
 	ExternalId NullableString `json:"external_id,omitempty"`


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] return empty from Go ErrorMessages for null envelopes
- fix: [SDK-4438] dispatch Go ErrorMessages array items individually
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._