### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -64,6 +64,20 @@ paths:
           example: 0
           type: integer
         style: form
+      - description: "Time-offset pagination cursor for sequential pulls of all messages.\
+          \  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`)\
+          \ or the opaque Base64 cursor token returned as `next_time_offset` in a\
+          \ prior response.  When set, results are sorted ascending by send_after\
+          \ and the standard `offset` parameter cannot be used.  Repeat the request\
+          \ with each `next_time_offset` until an empty notifications array is returned."
+        explode: true
+        in: query
+        name: time_offset
+        required: false
+        schema:
+          example: 2025-01-01T00:00:00.000Z
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -2934,8 +2948,10 @@ components:
     NotificationSlice:
       example:
         offset: 6
+        time_offset: time_offset
         total_count: 0
         limit: 1
+        next_time_offset: next_time_offset
         notifications:
         - null
         - null
@@ -2946,6 +2962,14 @@ components:
           type: integer
         limit:
           type: integer
+        time_offset:
+          description: "The time_offset cursor specified in the request, if any."
+          type: string
+        next_time_offset:
+          description: An opaque Base64 cursor token representing the next page of
+            messages to fetch.  Present when time_offset was provided in the request.  Pass
+            this value as time_offset on the next request to continue paginating.
+          type: string
         notifications:
           items:
             $ref: '#/components/schemas/NotificationWithMeta'
@@ -3619,9 +3643,12 @@ components:
         errors: ""
       properties:
         id:
-          description: Notification identifier when the request created a notification.
-            An empty string means no notification was created; read `errors` for details
-            (HTTP may still be 200).
+          description: "Notification identifier when the request created a notification.\
+            \ An empty string means no notification was created; read `errors` for\
+            \ details (HTTP may still be 200). All OneSignal server SDKs expose message-sent\
+            \ / message-not-sent narrowing helpers (named idiomatically per language\
+            \ — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer\
+            \ them over comparing `id` directly."
           type: string
         external_id:
           description: Optional correlation / idempotency-related value from the API

--- a/api_default.go
+++ b/api_default.go
@@ -3649,6 +3649,7 @@ type ApiGetNotificationsRequest struct {
 	limit *int32
 	offset *int32
 	kind *int32
+	timeOffset *string
 }
 
 // The app ID that you want to view notifications from
@@ -3672,6 +3673,12 @@ func (r ApiGetNotificationsRequest) Offset(offset int32) ApiGetNotificationsRequ
 // Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only 
 func (r ApiGetNotificationsRequest) Kind(kind int32) ApiGetNotificationsRequest {
 	r.kind = &kind
+	return r
+}
+
+// Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned.
+func (r ApiGetNotificationsRequest) TimeOffset(timeOffset string) ApiGetNotificationsRequest {
+	r.timeOffset = &timeOffset
 	return r
 }
 
@@ -3727,6 +3734,9 @@ func (a *DefaultApiService) GetNotificationsExecute(r ApiGetNotificationsRequest
 	}
 	if r.kind != nil {
 		localVarQueryParams.Add("kind", parameterToString(*r.kind, ""))
+	}
+	if r.timeOffset != nil {
+		localVarQueryParams.Add("time_offset", parameterToString(*r.timeOffset, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | Pointer to **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional] 
+**Id** | Pointer to **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional] 
 **ExternalId** | Pointer to **NullableString** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional] 
 **Errors** | Pointer to **interface{}** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -2301,7 +2301,7 @@ Name | Type | Description  | Notes
 
 ## GetNotifications
 
-> NotificationSlice GetNotifications(ctx).AppId(appId).Limit(limit).Offset(offset).Kind(kind).Execute()
+> NotificationSlice GetNotifications(ctx).AppId(appId).Limit(limit).Offset(offset).Kind(kind).TimeOffset(timeOffset).Execute()
 
 View notifications
 
@@ -2329,13 +2329,14 @@ func main() {
     limit := int32(10) // int32 | How many notifications to return.  Max is 50.  Default is 50. (optional)
     offset := int32(0) // int32 | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
     kind := int32(0) // int32 | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional)
+    timeOffset := "2025-01-01T00:00:00.000Z" // string | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned. (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
 
     restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY") // App REST API key required for most endpoints
 
-    resp, r, err := apiClient.DefaultApi.GetNotifications(restAuth).AppId(appId).Limit(limit).Offset(offset).Kind(kind).Execute()
+    resp, r, err := apiClient.DefaultApi.GetNotifications(restAuth).AppId(appId).Limit(limit).Offset(offset).Kind(kind).TimeOffset(timeOffset).Execute()
 
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.GetNotifications``: %v\n", err)
@@ -2367,6 +2368,7 @@ Name | Type | Description  | Notes
  **limit** | **int32** | How many notifications to return.  Max is 50.  Default is 50. | 
  **offset** | **int32** | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | 
  **kind** | **int32** | Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | 
+ **timeOffset** | **string** | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | 
 
 ### Return type
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **TotalCount** | Pointer to **int32** |  | [optional] 
 **Offset** | Pointer to **int32** |  | [optional] 
 **Limit** | Pointer to **int32** |  | [optional] 
+**TimeOffset** | Pointer to **string** | The time_offset cursor specified in the request, if any. | [optional] 
+**NextTimeOffset** | Pointer to **string** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional] 
 **Notifications** | Pointer to [**[]NotificationWithMeta**](NotificationWithMeta.md) |  | [optional] 
 
 ## Methods
@@ -102,6 +104,56 @@ SetLimit sets Limit field to given value.
 `func (o *NotificationSlice) HasLimit() bool`
 
 HasLimit returns a boolean if a field has been set.
+
+### GetTimeOffset
+
+`func (o *NotificationSlice) GetTimeOffset() string`
+
+GetTimeOffset returns the TimeOffset field if non-nil, zero value otherwise.
+
+### GetTimeOffsetOk
+
+`func (o *NotificationSlice) GetTimeOffsetOk() (*string, bool)`
+
+GetTimeOffsetOk returns a tuple with the TimeOffset field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetTimeOffset
+
+`func (o *NotificationSlice) SetTimeOffset(v string)`
+
+SetTimeOffset sets TimeOffset field to given value.
+
+### HasTimeOffset
+
+`func (o *NotificationSlice) HasTimeOffset() bool`
+
+HasTimeOffset returns a boolean if a field has been set.
+
+### GetNextTimeOffset
+
+`func (o *NotificationSlice) GetNextTimeOffset() string`
+
+GetNextTimeOffset returns the NextTimeOffset field if non-nil, zero value otherwise.
+
+### GetNextTimeOffsetOk
+
+`func (o *NotificationSlice) GetNextTimeOffsetOk() (*string, bool)`
+
+GetNextTimeOffsetOk returns a tuple with the NextTimeOffset field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetNextTimeOffset
+
+`func (o *NotificationSlice) SetNextTimeOffset(v string)`
+
+SetNextTimeOffset sets NextTimeOffset field to given value.
+
+### HasNextTimeOffset
+
+`func (o *NotificationSlice) HasNextTimeOffset() bool`
+
+HasNextTimeOffset returns a boolean if a field has been set.
 
 ### GetNotifications
 

--- a/helpers.go
+++ b/helpers.go
@@ -117,6 +117,28 @@ func retryDelay(httpResp *http.Response, attempt int, baseDelay time.Duration) t
 	return baseDelay * (1 << uint(attempt))
 }
 
+// MessageSent and MessageNotSent name the two branches of a POST /notifications
+// 200 response, which share the CreateNotificationSuccessResponse shape:
+// MessageSent is the branch where a notification was created (non-empty Id);
+// MessageNotSent is the branch where none was (empty Id, with Errors carrying
+// the reason). Use the IsMessageSent / IsMessageNotSent guards to discriminate.
+type MessageSent = CreateNotificationSuccessResponse
+type MessageNotSent = CreateNotificationSuccessResponse
+
+// IsMessageSent reports whether a POST /notifications 200 response is the
+// "message sent" branch — a notification was created (Id is a non-empty
+// string). Prefer this over inspecting Id directly.
+func IsMessageSent(response *CreateNotificationSuccessResponse) bool {
+	return response != nil && response.GetId() != ""
+}
+
+// IsMessageNotSent reports whether a POST /notifications 200 response is the
+// "message not sent" branch — no notification was created (Id is absent or
+// empty); inspect Errors for why.
+func IsMessageNotSent(response *CreateNotificationSuccessResponse) bool {
+	return !IsMessageSent(response)
+}
+
 func newUUIDv4() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/model_create_notification_success_response.go
+++ b/model_create_notification_success_response.go
@@ -17,7 +17,7 @@ import (
 
 // CreateNotificationSuccessResponse struct for CreateNotificationSuccessResponse
 type CreateNotificationSuccessResponse struct {
-	// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+	// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
 	Id *string `json:"id,omitempty"`
 	// Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).
 	ExternalId NullableString `json:"external_id,omitempty"`

--- a/model_notification_slice.go
+++ b/model_notification_slice.go
@@ -20,6 +20,10 @@ type NotificationSlice struct {
 	TotalCount *int32 `json:"total_count,omitempty"`
 	Offset *int32 `json:"offset,omitempty"`
 	Limit *int32 `json:"limit,omitempty"`
+	// The time_offset cursor specified in the request, if any.
+	TimeOffset *string `json:"time_offset,omitempty"`
+	// An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+	NextTimeOffset *string `json:"next_time_offset,omitempty"`
 	Notifications []NotificationWithMeta `json:"notifications,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
@@ -139,6 +143,70 @@ func (o *NotificationSlice) SetLimit(v int32) {
 	o.Limit = &v
 }
 
+// GetTimeOffset returns the TimeOffset field value if set, zero value otherwise.
+func (o *NotificationSlice) GetTimeOffset() string {
+	if o == nil || o.TimeOffset == nil {
+		var ret string
+		return ret
+	}
+	return *o.TimeOffset
+}
+
+// GetTimeOffsetOk returns a tuple with the TimeOffset field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *NotificationSlice) GetTimeOffsetOk() (*string, bool) {
+	if o == nil || o.TimeOffset == nil {
+		return nil, false
+	}
+	return o.TimeOffset, true
+}
+
+// HasTimeOffset returns a boolean if a field has been set.
+func (o *NotificationSlice) HasTimeOffset() bool {
+	if o != nil && o.TimeOffset != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTimeOffset gets a reference to the given string and assigns it to the TimeOffset field.
+func (o *NotificationSlice) SetTimeOffset(v string) {
+	o.TimeOffset = &v
+}
+
+// GetNextTimeOffset returns the NextTimeOffset field value if set, zero value otherwise.
+func (o *NotificationSlice) GetNextTimeOffset() string {
+	if o == nil || o.NextTimeOffset == nil {
+		var ret string
+		return ret
+	}
+	return *o.NextTimeOffset
+}
+
+// GetNextTimeOffsetOk returns a tuple with the NextTimeOffset field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *NotificationSlice) GetNextTimeOffsetOk() (*string, bool) {
+	if o == nil || o.NextTimeOffset == nil {
+		return nil, false
+	}
+	return o.NextTimeOffset, true
+}
+
+// HasNextTimeOffset returns a boolean if a field has been set.
+func (o *NotificationSlice) HasNextTimeOffset() bool {
+	if o != nil && o.NextTimeOffset != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNextTimeOffset gets a reference to the given string and assigns it to the NextTimeOffset field.
+func (o *NotificationSlice) SetNextTimeOffset(v string) {
+	o.NextTimeOffset = &v
+}
+
 // GetNotifications returns the Notifications field value if set, zero value otherwise.
 func (o *NotificationSlice) GetNotifications() []NotificationWithMeta {
 	if o == nil || o.Notifications == nil {
@@ -182,6 +250,12 @@ func (o NotificationSlice) MarshalJSON() ([]byte, error) {
 	if o.Limit != nil {
 		toSerialize["limit"] = o.Limit
 	}
+	if o.TimeOffset != nil {
+		toSerialize["time_offset"] = o.TimeOffset
+	}
+	if o.NextTimeOffset != nil {
+		toSerialize["next_time_offset"] = o.NextTimeOffset
+	}
 	if o.Notifications != nil {
 		toSerialize["notifications"] = o.Notifications
 	}
@@ -206,6 +280,8 @@ func (o *NotificationSlice) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "total_count")
 		delete(additionalProperties, "offset")
 		delete(additionalProperties, "limit")
+		delete(additionalProperties, "time_offset")
+		delete(additionalProperties, "next_time_offset")
 		delete(additionalProperties, "notifications")
 		o.AdditionalProperties = additionalProperties
 	}


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] return empty from Go ErrorMessages for null envelopes
- fix: [SDK-4438] dispatch Go ErrorMessages array items individually
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...2907ac8](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...2907ac87ca594fc5aee71ccfab5839f35b6a0f38)._