### PR TITLE
feat: add v5.8.0 package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every SDK requires authentication via API keys. Two key types are available:
 > **Warning:** Store your API keys in environment variables or a secrets manager. Never commit them to source control.
 
 ```go
-import onesignal "github.com/OneSignal/onesignal-go-api"
+import onesignal "github.com/OneSignal/onesignal-go-api/v5"
 
 restAuth := context.WithValue(
     context.Background(),
@@ -42,14 +42,14 @@ apiClient := onesignal.NewAPIClient(onesignal.NewConfiguration())
 
 ```go
 notification := *onesignal.NewNotification("YOUR_APP_ID")
-notification.SetContents(onesignal.StringMap{En: onesignal.PtrString("Hello from OneSignal!")})
-notification.SetHeadings(onesignal.StringMap{En: onesignal.PtrString("Push Notification")})
+notification.SetContents(onesignal.LanguageStringMap{En: onesignal.PtrString("Hello from OneSignal!")})
+notification.SetHeadings(onesignal.LanguageStringMap{En: onesignal.PtrString("Push Notification")})
 notification.SetIncludedSegments([]string{"Subscribed Users"})
 
-response, _, err := apiClient.DefaultApi
-    .CreateNotification(orgAuth)
-    .Notification(notification)
-    .Execute()
+response, _, err := apiClient.DefaultApi.
+    CreateNotification(orgAuth).
+    Notification(notification).
+    Execute()
 
 if err != nil {
     log.Fatal(err)
@@ -64,27 +64,27 @@ notification := *onesignal.NewNotification("YOUR_APP_ID")
 notification.SetEmailSubject("Important Update")
 notification.SetEmailBody("<h1>Hello!</h1><p>This is an HTML email.</p>")
 notification.SetIncludedSegments([]string{"Subscribed Users"})
-notification.SetChannelForExternalUserIds("email")
+notification.SetTargetChannel("email")
 
-response, _, err := apiClient.DefaultApi
-    .CreateNotification(orgAuth)
-    .Notification(notification)
-    .Execute()
+response, _, err := apiClient.DefaultApi.
+    CreateNotification(orgAuth).
+    Notification(notification).
+    Execute()
 ```
 
 ## Send an SMS
 
 ```go
 notification := *onesignal.NewNotification("YOUR_APP_ID")
-notification.SetContents(onesignal.StringMap{En: onesignal.PtrString("Your SMS message content here")})
+notification.SetContents(onesignal.LanguageStringMap{En: onesignal.PtrString("Your SMS message content here")})
 notification.SetIncludedSegments([]string{"Subscribed Users"})
-notification.SetChannelForExternalUserIds("sms")
+notification.SetTargetChannel("sms")
 notification.SetSmsFrom("+15551234567")
 
-response, _, err := apiClient.DefaultApi
-    .CreateNotification(orgAuth)
-    .Notification(notification)
-    .Execute()
+response, _, err := apiClient.DefaultApi.
+    CreateNotification(orgAuth).
+    Notification(notification).
+    Execute()
 ```
 
 ## Full API reference

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -110,7 +110,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -192,7 +192,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -276,7 +276,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -364,7 +364,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -449,7 +449,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -531,7 +531,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -607,7 +607,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -690,7 +690,7 @@ import (
     "os"
 
     "github.com/google/uuid"
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -749,7 +749,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -829,7 +829,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -911,7 +911,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -999,7 +999,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1075,7 +1075,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1112,7 +1112,8 @@ A `409` from this endpoint deserializes to `CreateUserConflictResponse`. `ErrorM
 if apiErr, ok := err.(*onesignal.GenericOpenAPIError); ok {
     if conflict, ok := apiErr.Model().(onesignal.CreateUserConflictResponse); ok {
         for _, e := range conflict.GetErrors() {
-            fmt.Println(e.GetTitle(), e.GetMeta().GetConflictingAliases())
+            meta := e.GetMeta()
+            fmt.Println(e.GetTitle(), meta.GetConflictingAliases())
         }
     }
 }
@@ -1171,7 +1172,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1260,7 +1261,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1343,7 +1344,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1426,7 +1427,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1438,7 +1439,7 @@ func main() {
 
     restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY") // App REST API key required for most endpoints
 
-    resp, r, err := apiClient.DefaultApi.DeleteSubscription(restAuth, appId, subscriptionId).Execute()
+    r, err := apiClient.DefaultApi.DeleteSubscription(restAuth, appId, subscriptionId).Execute()
 
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteSubscription``: %v\n", err)
@@ -1507,7 +1508,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1589,7 +1590,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1602,7 +1603,7 @@ func main() {
 
     restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY") // App REST API key required for most endpoints
 
-    resp, r, err := apiClient.DefaultApi.DeleteUser(restAuth, appId, aliasLabel, aliasId).Execute()
+    r, err := apiClient.DefaultApi.DeleteUser(restAuth, appId, aliasLabel, aliasId).Execute()
 
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteUser``: %v\n", err)
@@ -1673,7 +1674,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1755,7 +1756,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1837,7 +1838,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -1923,7 +1924,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2006,7 +2007,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2086,7 +2087,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2157,7 +2158,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2239,7 +2240,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2321,7 +2322,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2405,7 +2406,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2495,7 +2496,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2579,7 +2580,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2665,7 +2666,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2748,13 +2749,13 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
     appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
     activityType := "order_status" // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
-    startLiveActivityRequest := *onesignal.NewStartLiveActivityRequest("Name_example", "Event_example", "ActivityId_example", map[string]interface{}(123), map[string]interface{}(123), *onesignal.NewLanguageStringMap(), *onesignal.NewLanguageStringMap()) // StartLiveActivityRequest | 
+    startLiveActivityRequest := *onesignal.NewStartLiveActivityRequest("Name_example", "Event_example", "ActivityId_example", map[string]interface{}{"key": "value"}, map[string]interface{}{"key": "value"}, *onesignal.NewLanguageStringMap(), *onesignal.NewLanguageStringMap()) // StartLiveActivityRequest | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2833,7 +2834,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -2918,7 +2919,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3003,7 +3004,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3088,7 +3089,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3170,13 +3171,13 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
     appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     activityId := "12345" // string | Live Activity record ID
-    updateLiveActivityRequest := *onesignal.NewUpdateLiveActivityRequest("Name_example", "Event_example", map[string]interface{}(123)) // UpdateLiveActivityRequest | 
+    updateLiveActivityRequest := *onesignal.NewUpdateLiveActivityRequest("Name_example", "Event_example", map[string]interface{}{"key": "value"}) // UpdateLiveActivityRequest | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3255,7 +3256,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3268,7 +3269,7 @@ func main() {
 
     restAuth := context.WithValue(context.Background(), onesignal.RestApiKey, "YOUR_REST_API_KEY") // App REST API key required for most endpoints
 
-    resp, r, err := apiClient.DefaultApi.UpdateSubscription(restAuth, appId, subscriptionId).SubscriptionBody(subscriptionBody).Execute()
+    r, err := apiClient.DefaultApi.UpdateSubscription(restAuth, appId, subscriptionId).SubscriptionBody(subscriptionBody).Execute()
 
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateSubscription``: %v\n", err)
@@ -3338,7 +3339,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3426,7 +3427,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3510,7 +3511,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3598,7 +3599,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3678,7 +3679,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {
@@ -3760,7 +3761,7 @@ import (
     "fmt"
     "os"
 
-    "github.com/OneSignal/onesignal-go-api"
+    "github.com/OneSignal/onesignal-go-api/v5"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/OneSignal/onesignal-go-api/v5
 
-go 1.13
+go 1.23.0
 
 require (
-	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
+	golang.org/x/oauth2 v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,4 @@
-cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
-github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
-golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
-golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
-golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
-google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=


### PR DESCRIPTION
## Release v5.8.0

### 📚 Docs
- docs: [SDK-4817] fix Go DefaultApi.md/README import path, no-body signatures, model name
- docs: [SDK-4817] emit valid Go map literal for free-form object examples
- docs: [SDK-4817] fix Go README hero examples (method chain + target channel)
- docs: [SDK-4817] fix Go CreateUser 409-conflict snippet (addressable meta)

---
_Generated from [OneSignal/api-client-libraries@1d424a7...63e8030](https://github.com/OneSignal/api-client-libraries/compare/1d424a73920401d0d49a3a51420a270c9b1542d5...63e80303e2c8e733e7bbf1dfeeb05a81ef6b30bb)._