### PR TITLE
feat: add v5.9.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,7 +23,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - description: How many notifications to return.  Max is 50.  Default is 50.
@@ -174,7 +174,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - explode: false
@@ -229,7 +229,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - explode: false
@@ -441,7 +441,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       responses:
@@ -483,7 +483,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -531,7 +531,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "Segments are listed in ascending order of created_at date. offset\
@@ -599,7 +599,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -657,7 +657,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The segment_id can be found in the URL of the segment when viewing
@@ -719,7 +719,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "Required\nComma-separated list of names and the value (sum/count)\
@@ -821,7 +821,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The name of the Live Activity defined in your app. This should
@@ -879,7 +879,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: Live Activity record ID
@@ -937,7 +937,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -1003,7 +1003,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1060,7 +1060,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1121,7 +1121,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1189,7 +1189,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1251,7 +1251,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1325,7 +1325,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1402,7 +1402,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1483,7 +1483,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1538,7 +1538,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1600,7 +1600,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1647,7 +1647,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1714,7 +1714,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1782,7 +1782,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The type of token to use when looking up the subscription. See
@@ -1851,7 +1851,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "The id of the message found in the creation notification POST\
@@ -1954,7 +1954,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -2029,7 +2029,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2077,7 +2077,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - description: Maximum number of templates. Default and max is 50.
@@ -2196,7 +2196,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2244,7 +2244,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2292,7 +2292,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       requestBody:
@@ -2341,7 +2341,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       requestBody:
@@ -2383,7 +2383,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       responses:
@@ -2420,7 +2420,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -2463,7 +2463,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2506,7 +2506,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2558,7 +2558,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2604,7 +2604,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -3289,20 +3289,23 @@ components:
       type: object
     Purchase:
       example:
-        amount: amount
-        iso: iso
+        amount: "0.99"
+        iso: USD
         count: 2
-        sku: sku
+        sku: com.example.coins100
       properties:
         sku:
           description: The unique identifier of the purchased item.
+          example: com.example.coins100
           type: string
         amount:
           description: "The amount, in USD, spent purchasing the item."
+          example: "0.99"
           type: string
         iso:
           description: The 3-letter ISO 4217 currency code. Required for correct storage
             and conversion of amount.
+          example: USD
           type: string
         count:
           type: integer
@@ -3351,18 +3354,22 @@ components:
         field:
           description: Required. Name of the field to use as the first operand in
             the filter expression.
+          example: tag
           type: string
         key:
           description: "If `field` is `tag`, this field is *required* to specify `key`\
             \ inside the tags."
+          example: level
           type: string
         value:
           description: Constant value to use as the second operand in the filter expression.
             This value is *required* when the relation operator is a binary operator.
+          example: "10"
           type: string
         hours_ago:
           description: "If `field` is session-related, this is *required* to specify\
             \ the number of hours before or after the user's session."
+          example: "24"
           type: string
         radius:
           description: "If `field` is `location`, this will specify the radius in\
@@ -3405,17 +3412,19 @@ components:
       - $ref: '#/components/schemas/Operator'
     Segment:
       example:
-        name: name
-        id: id
+        name: Inactive 30 days
+        id: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
         filters:
         - null
         - null
       properties:
         id:
           description: "UUID of the segment.  If left empty, it will be assigned automaticaly."
+          example: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
           type: string
         name:
           description: Name of the segment.  You'll see this name on the Web UI.
+          example: Inactive 30 days
           type: string
         filters:
           description: "Filter or operators the segment will have.  For a list of\
@@ -3641,42 +3650,51 @@ components:
     IdentityObject:
       additionalProperties:
         type: string
+      example:
+        external_id: YOUR_USER_EXTERNAL_ID
       type: object
     PropertiesObject:
       example:
-        country: country
+        country: US
         purchases:
-        - amount: amount
-          iso: iso
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        - amount: amount
-          iso: iso
+          sku: com.example.coins100
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        ip: ip
-        timezone_id: timezone_id
-        language: language
+          sku: com.example.coins100
+        ip: 203.0.113.10
+        timezone_id: America/Los_Angeles
+        language: en
         first_active: 1
         last_active: 5
         lat: 0.8008281904610115
         long: 6.027456183070403
         tags:
-          key: ""
+          level: "10"
+          vip: "true"
         amount_spent: 5.637376656633329
       properties:
         tags:
           additionalProperties: true
+          example:
+            level: "10"
+            vip: "true"
           type: object
         language:
+          example: en
           type: string
         timezone_id:
+          example: America/Los_Angeles
           type: string
         lat:
           type: number
         long:
           type: number
         country:
+          example: US
           type: string
         first_active:
           type: integer
@@ -3689,19 +3707,20 @@ components:
             $ref: '#/components/schemas/Purchase'
           type: array
         ip:
+          example: 203.0.113.10
           type: string
       type: object
     PropertiesDeltas:
       example:
         purchases:
-        - amount: amount
-          iso: iso
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        - amount: amount
-          iso: iso
+          sku: com.example.coins100
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
+          sku: com.example.coins100
         session_count: 6
         session_time: 0
       properties:
@@ -3716,25 +3735,26 @@ components:
       type: object
     Subscription:
       example:
-        notification_types: 7
-        device_model: device_model
-        app_version: app_version
-        web_p256: web_p256
-        net_type: 4
+        notification_types: 1
+        device_model: "iPhone14,2"
+        app_version: 1.0.0
+        web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+        net_type: 9
         type: iOSPush
-        device_os: device_os
+        device_os: "17.1"
         enabled: true
-        session_time: 9
-        test_type: 2
-        token: token
-        carrier: carrier
-        session_count: 3
-        web_auth: web_auth
+        session_time: 60
+        test_type: 7
+        token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+        carrier: Verizon
+        session_count: 1
+        web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
         rooted: true
-        id: id
-        sdk: sdk
+        id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+        sdk: 5.2.0
       properties:
         id:
+          example: e4e87830-b954-4363-b7bc-1f01dbaee5c8
           type: string
         type:
           enum:
@@ -3753,95 +3773,108 @@ components:
           - SMS
           type: string
         token:
+          example: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
           type: string
         enabled:
+          example: true
           type: boolean
         notification_types:
+          example: 1
           type: integer
         session_time:
+          example: 60
           type: integer
         session_count:
+          example: 1
           type: integer
         sdk:
+          example: 5.2.0
           type: string
         device_model:
+          example: "iPhone14,2"
           type: string
         device_os:
+          example: "17.1"
           type: string
         rooted:
           type: boolean
         test_type:
           type: integer
         app_version:
+          example: 1.0.0
           type: string
         net_type:
           type: integer
         carrier:
+          example: Verizon
           type: string
         web_auth:
+          example: 5DUmpGmLuTxWCLj5lJpwLQ
           type: string
         web_p256:
+          example: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
           type: string
       type: object
     User:
       example:
         subscriptions:
-        - notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+        - notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
-        - notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
+        - notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
         identity:
-          key: identity
+          external_id: YOUR_USER_EXTERNAL_ID
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -3849,6 +3882,8 @@ components:
         identity:
           additionalProperties:
             type: string
+          example:
+            external_id: YOUR_USER_EXTERNAL_ID
           type: object
         subscriptions:
           items:
@@ -3860,36 +3895,37 @@ components:
         refresh_device_metadata: false
         deltas:
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
+            sku: com.example.coins100
           session_count: 6
           session_time: 0
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -4688,25 +4724,26 @@ components:
     PropertiesBody:
       example:
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -4715,23 +4752,23 @@ components:
     SubscriptionBody:
       example:
         subscription:
-          notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+          notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
       properties:
         subscription:
           $ref: '#/components/schemas/Subscription'
@@ -4751,11 +4788,13 @@ components:
     UserIdentityBody:
       example:
         identity:
-          key: identity
+          external_id: YOUR_USER_EXTERNAL_ID
       properties:
         identity:
           additionalProperties:
             type: string
+          example:
+            external_id: YOUR_USER_EXTERNAL_ID
           type: object
       type: object
     ExportEventsSuccessResponse:
@@ -5719,6 +5758,7 @@ components:
             \ the `include_unsubscribed` value from the template will be inherited.\
             \ If you are using a third-party ESP, this field requires the ESP's list\
             \ of unsubscribed emails to be cleared."
+          nullable: true
           type: boolean
           writeOnly: true
         email_bcc:

--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -109,7 +109,7 @@ Name | Type | Description | Notes
 **EmailReplyToAddress** | Pointer to **NullableString** | Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address.  | [optional] 
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
-**IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**IncludeUnsubscribed** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
@@ -3606,6 +3606,16 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### SetIncludeUnsubscribedNil
+
+`func (o *BasicNotification) SetIncludeUnsubscribedNil(b bool)`
+
+ SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+
+### UnsetIncludeUnsubscribed
+`func (o *BasicNotification) UnsetIncludeUnsubscribed()`
+
+UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
 ### GetEmailBcc
 
 `func (o *BasicNotification) GetEmailBcc() []string`

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -95,7 +95,7 @@ Name | Type | Description | Notes
 **EmailReplyToAddress** | Pointer to **NullableString** | Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address.  | [optional] 
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
-**IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**IncludeUnsubscribed** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
@@ -3227,6 +3227,16 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### SetIncludeUnsubscribedNil
+
+`func (o *BasicNotificationAllOf) SetIncludeUnsubscribedNil(b bool)`
+
+ SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+
+### UnsetIncludeUnsubscribed
+`func (o *BasicNotificationAllOf) UnsetIncludeUnsubscribed()`
+
+UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
 ### GetEmailBcc
 
 `func (o *BasicNotificationAllOf) GetEmailBcc() []string`

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -114,7 +114,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -197,7 +197,7 @@ import (
 
 func main() {
     templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     copyTemplateRequest := *onesignal.NewCopyTemplateRequest("TargetAppId_example") // CopyTemplateRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -280,7 +280,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     userIdentityBody := *onesignal.NewUserIdentityBody() // UserIdentityBody | 
@@ -368,7 +368,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     userIdentityBody := *onesignal.NewUserIdentityBody() // UserIdentityBody | 
 
@@ -453,7 +453,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     createApiKeyRequest := *onesignal.NewCreateApiKeyRequest() // CreateApiKeyRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -611,7 +611,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    appId := "YOUR_APP_ID" // string | Your OneSignal App ID in UUID v4 format.
     customEventsRequest := *onesignal.NewCustomEventsRequest([]onesignal.CustomEvent{*onesignal.NewCustomEvent("Name_example")}) // CustomEventsRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -703,6 +703,9 @@ func main() {
     contents := onesignal.NewLanguageStringMap()
     contents.SetEn("Hello from OneSignal!")
     notification.SetContents(*contents)
+    headings := onesignal.NewLanguageStringMap()
+    headings.SetEn("Push Notification")
+    notification.SetHeadings(*headings)
     notification.SetIncludeAliases(map[string][]string{"external_id": {"YOUR_USER_EXTERNAL_ID"}})
     notification.SetTargetChannel("push")
     // Idempotency key: a client-generated UUID that lets you safely retry on network failure.
@@ -762,6 +765,9 @@ func main() {
     contents := onesignal.NewLanguageStringMap()
     contents.SetEn("Hello from OneSignal!")
     notification.SetContents(*contents)
+    headings := onesignal.NewLanguageStringMap()
+    headings.SetEn("Push Notification")
+    notification.SetHeadings(*headings)
     notification.SetIncludeAliases(map[string][]string{"external_id": {"YOUR_USER_EXTERNAL_ID"}})
     notification.SetTargetChannel("push")
     // No idempotency key set: the helper generates a UUIDv4 and reuses it across retries.
@@ -833,8 +839,8 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-    segment := *onesignal.NewSegment("Name_example", []onesignal.FilterExpression{onesignal.FilterExpression{Filter: onesignal.NewFilter()}}) // Segment |  (optional)
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    segment := *onesignal.NewSegment("Inactive 30 days", []onesignal.FilterExpression{onesignal.FilterExpression{Filter: onesignal.NewFilter()}}) // Segment |  (optional)
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -915,7 +921,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
@@ -1079,7 +1085,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     user := *onesignal.NewUser() // User | 
 
     configuration := onesignal.NewConfiguration()
@@ -1176,7 +1182,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     aliasLabelToDelete := "external_id" // string | 
@@ -1265,7 +1271,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -1348,7 +1354,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     segmentId := "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e" // string | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
 
     configuration := onesignal.NewConfiguration()
@@ -1431,7 +1437,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -1513,7 +1519,7 @@ import (
 
 func main() {
     templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1594,7 +1600,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
@@ -1679,7 +1685,7 @@ import (
 
 func main() {
     notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | The ID of the notification to export events from.
-    appId := "00000000-0000-0000-0000-000000000000" // string | The ID of the app that the notification belongs to.
+    appId := "YOUR_APP_ID" // string | The ID of the app that the notification belongs to.
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -1760,7 +1766,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The app ID that you want to export devices from
+    appId := "YOUR_APP_ID" // string | The app ID that you want to export devices from
     exportSubscriptionsRequestBody := *onesignal.NewExportSubscriptionsRequestBody() // ExportSubscriptionsRequestBody |  (optional)
 
     configuration := onesignal.NewConfiguration()
@@ -1842,7 +1848,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
@@ -1928,7 +1934,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -2011,7 +2017,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | An app id
+    appId := "YOUR_APP_ID" // string | An app id
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -2162,7 +2168,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -2326,7 +2332,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The app ID that you want to view notifications from
+    appId := "YOUR_APP_ID" // string | The app ID that you want to view notifications from
     limit := int32(10) // int32 | How many notifications to return.  Max is 50.  Default is 50. (optional)
     offset := int32(0) // int32 | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
     kind := int32(0) // int32 | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional)
@@ -2410,7 +2416,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     outcomeNames := "os__session_duration.count,os__click.count" // string | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
     outcomeNames2 := "os__session_duration.count" // string | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional)
     outcomeTimeRange := "1d" // string | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional)
@@ -2500,7 +2506,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     offset := int32(0) // int32 | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional)
     limit := int32(10) // int32 | The amount of Segments in the response. Maximum 300. (optional)
 
@@ -2584,7 +2590,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
 
@@ -2670,7 +2676,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
 
     configuration := onesignal.NewConfiguration()
@@ -2753,7 +2759,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    appId := "YOUR_APP_ID" // string | Your OneSignal App ID in UUID v4 format.
     activityType := "order_status" // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
     startLiveActivityRequest := *onesignal.NewStartLiveActivityRequest("Name_example", "Event_example", "ActivityId_example", map[string]interface{}{"key": "value"}, map[string]interface{}{"key": "value"}, *onesignal.NewLanguageStringMap(), *onesignal.NewLanguageStringMap()) // StartLiveActivityRequest | 
 
@@ -2838,7 +2844,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     transferSubscriptionRequestBody := *onesignal.NewTransferSubscriptionRequestBody() // TransferSubscriptionRequestBody | 
 
@@ -2923,7 +2929,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     notificationId := "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88" // string | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
     token := "YOUR_TOKEN_ID" // string | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
 
@@ -3008,7 +3014,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     tokenId := "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff" // string | 
     updateApiKeyRequest := *onesignal.NewUpdateApiKeyRequest() // UpdateApiKeyRequest | 
 
@@ -3093,7 +3099,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | An app id
+    appId := "YOUR_APP_ID" // string | An app id
     app := *onesignal.NewApp() // App | 
 
     configuration := onesignal.NewConfiguration()
@@ -3175,7 +3181,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+    appId := "YOUR_APP_ID" // string | The OneSignal App ID for your app.  Available in Keys & IDs.
     activityId := "12345" // string | Live Activity record ID
     updateLiveActivityRequest := *onesignal.NewUpdateLiveActivityRequest("Name_example", "Event_example", map[string]interface{}{"key": "value"}) // UpdateLiveActivityRequest | 
 
@@ -3260,7 +3266,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     subscriptionId := "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51" // string | 
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
 
@@ -3343,7 +3349,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    appId := "YOUR_APP_ID" // string | Your OneSignal App ID in UUID v4 format.
     tokenType := "Email" // string | The type of token to use when looking up the subscription. See Subscription Types.
     token := "user@example.com" // string | The value of the token to lookup by (e.g., email address, phone number).
     subscriptionBody := *onesignal.NewSubscriptionBody() // SubscriptionBody | 
@@ -3432,7 +3438,7 @@ import (
 
 func main() {
     templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     updateTemplateRequest := *onesignal.NewUpdateTemplateRequest() // UpdateTemplateRequest | 
 
     configuration := onesignal.NewConfiguration()
@@ -3515,7 +3521,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
     aliasLabel := "external_id" // string | 
     aliasId := "YOUR_USER_EXTERNAL_ID" // string | 
     updateUserRequest := *onesignal.NewUpdateUserRequest() // UpdateUserRequest | 
@@ -3603,7 +3609,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3684,7 +3690,7 @@ import (
 
 func main() {
     templateId := "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c" // string | 
-    appId := "00000000-0000-0000-0000-000000000000" // string | 
+    appId := "YOUR_APP_ID" // string | 
 
     configuration := onesignal.NewConfiguration()
     apiClient := onesignal.NewAPIClient(configuration)
@@ -3765,7 +3771,7 @@ import (
 )
 
 func main() {
-    appId := "00000000-0000-0000-0000-000000000000" // string | Your OneSignal App ID in UUID v4 format.
+    appId := "YOUR_APP_ID" // string | Your OneSignal App ID in UUID v4 format.
     limit := int32(10) // int32 | Maximum number of templates. Default and max is 50. (optional) (default to 50)
     offset := int32(0) // int32 | Pagination offset. (optional) (default to 0)
     channel := "push" // string | Filter by delivery channel. (optional)

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -109,7 +109,7 @@ Name | Type | Description | Notes
 **EmailReplyToAddress** | Pointer to **NullableString** | Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address.  | [optional] 
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
-**IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**IncludeUnsubscribed** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
@@ -3607,6 +3607,16 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### SetIncludeUnsubscribedNil
+
+`func (o *Notification) SetIncludeUnsubscribedNil(b bool)`
+
+ SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+
+### UnsetIncludeUnsubscribed
+`func (o *Notification) UnsetIncludeUnsubscribed()`
+
+UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
 ### GetEmailBcc
 
 `func (o *Notification) GetEmailBcc() []string`

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -109,7 +109,7 @@ Name | Type | Description | Notes
 **EmailReplyToAddress** | Pointer to **NullableString** | Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address.  | [optional] 
 **EmailPreheader** | Pointer to **NullableString** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] 
 **DisableEmailClickTracking** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] 
-**IncludeUnsubscribed** | Pointer to **bool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
+**IncludeUnsubscribed** | Pointer to **NullableBool** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] 
 **EmailBcc** | Pointer to **[]string** | BCC recipients that were set on this email notification. | [optional] 
 **EmailSenderDomain** | Pointer to **NullableString** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] 
 **SmsFrom** | Pointer to **NullableString** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] 
@@ -3619,6 +3619,16 @@ SetIncludeUnsubscribed sets IncludeUnsubscribed field to given value.
 
 HasIncludeUnsubscribed returns a boolean if a field has been set.
 
+### SetIncludeUnsubscribedNil
+
+`func (o *NotificationWithMeta) SetIncludeUnsubscribedNil(b bool)`
+
+ SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+
+### UnsetIncludeUnsubscribed
+`func (o *NotificationWithMeta) UnsetIncludeUnsubscribed()`
+
+UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
 ### GetEmailBcc
 
 `func (o *NotificationWithMeta) GetEmailBcc() []string`

--- a/model_basic_notification.go
+++ b/model_basic_notification.go
@@ -222,7 +222,7 @@ type BasicNotification struct {
 	// Channel: Email Default is `false`. If set to `true`, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked.
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
-	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	IncludeUnsubscribed NullableBool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
@@ -4373,36 +4373,46 @@ func (o *BasicNotification) UnsetDisableEmailClickTracking() {
 	o.DisableEmailClickTracking.Unset()
 }
 
-// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise.
+// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotification) GetIncludeUnsubscribed() bool {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil || o.IncludeUnsubscribed.Get() == nil {
 		var ret bool
 		return ret
 	}
-	return *o.IncludeUnsubscribed
+	return *o.IncludeUnsubscribed.Get()
 }
 
 // GetIncludeUnsubscribedOk returns a tuple with the IncludeUnsubscribed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotification) GetIncludeUnsubscribedOk() (*bool, bool) {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.IncludeUnsubscribed, true
+	return o.IncludeUnsubscribed.Get(), o.IncludeUnsubscribed.IsSet()
 }
 
 // HasIncludeUnsubscribed returns a boolean if a field has been set.
 func (o *BasicNotification) HasIncludeUnsubscribed() bool {
-	if o != nil && o.IncludeUnsubscribed != nil {
+	if o != nil && o.IncludeUnsubscribed.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetIncludeUnsubscribed gets a reference to the given bool and assigns it to the IncludeUnsubscribed field.
+// SetIncludeUnsubscribed gets a reference to the given NullableBool and assigns it to the IncludeUnsubscribed field.
 func (o *BasicNotification) SetIncludeUnsubscribed(v bool) {
-	o.IncludeUnsubscribed = &v
+	o.IncludeUnsubscribed.Set(&v)
+}
+// SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+func (o *BasicNotification) SetIncludeUnsubscribedNil() {
+	o.IncludeUnsubscribed.Set(nil)
+}
+
+// UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
+func (o *BasicNotification) UnsetIncludeUnsubscribed() {
+	o.IncludeUnsubscribed.Unset()
 }
 
 // GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -5148,8 +5158,8 @@ func (o BasicNotification) MarshalJSON() ([]byte, error) {
 	if o.DisableEmailClickTracking.IsSet() {
 		toSerialize["disable_email_click_tracking"] = o.DisableEmailClickTracking.Get()
 	}
-	if o.IncludeUnsubscribed != nil {
-		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
+	if o.IncludeUnsubscribed.IsSet() {
+		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed.Get()
 	}
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc

--- a/model_basic_notification_all_of.go
+++ b/model_basic_notification_all_of.go
@@ -194,7 +194,7 @@ type BasicNotificationAllOf struct {
 	// Channel: Email Default is `false`. If set to `true`, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked.
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
-	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	IncludeUnsubscribed NullableBool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
@@ -3899,36 +3899,46 @@ func (o *BasicNotificationAllOf) UnsetDisableEmailClickTracking() {
 	o.DisableEmailClickTracking.Unset()
 }
 
-// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise.
+// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BasicNotificationAllOf) GetIncludeUnsubscribed() bool {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil || o.IncludeUnsubscribed.Get() == nil {
 		var ret bool
 		return ret
 	}
-	return *o.IncludeUnsubscribed
+	return *o.IncludeUnsubscribed.Get()
 }
 
 // GetIncludeUnsubscribedOk returns a tuple with the IncludeUnsubscribed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *BasicNotificationAllOf) GetIncludeUnsubscribedOk() (*bool, bool) {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.IncludeUnsubscribed, true
+	return o.IncludeUnsubscribed.Get(), o.IncludeUnsubscribed.IsSet()
 }
 
 // HasIncludeUnsubscribed returns a boolean if a field has been set.
 func (o *BasicNotificationAllOf) HasIncludeUnsubscribed() bool {
-	if o != nil && o.IncludeUnsubscribed != nil {
+	if o != nil && o.IncludeUnsubscribed.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetIncludeUnsubscribed gets a reference to the given bool and assigns it to the IncludeUnsubscribed field.
+// SetIncludeUnsubscribed gets a reference to the given NullableBool and assigns it to the IncludeUnsubscribed field.
 func (o *BasicNotificationAllOf) SetIncludeUnsubscribed(v bool) {
-	o.IncludeUnsubscribed = &v
+	o.IncludeUnsubscribed.Set(&v)
+}
+// SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+func (o *BasicNotificationAllOf) SetIncludeUnsubscribedNil() {
+	o.IncludeUnsubscribed.Set(nil)
+}
+
+// UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
+func (o *BasicNotificationAllOf) UnsetIncludeUnsubscribed() {
+	o.IncludeUnsubscribed.Unset()
 }
 
 // GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -4632,8 +4642,8 @@ func (o BasicNotificationAllOf) MarshalJSON() ([]byte, error) {
 	if o.DisableEmailClickTracking.IsSet() {
 		toSerialize["disable_email_click_tracking"] = o.DisableEmailClickTracking.Get()
 	}
-	if o.IncludeUnsubscribed != nil {
-		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
+	if o.IncludeUnsubscribed.IsSet() {
+		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed.Get()
 	}
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc

--- a/model_notification.go
+++ b/model_notification.go
@@ -223,7 +223,7 @@ type Notification struct {
 	// Channel: Email Default is `false`. If set to `true`, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked.
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
-	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	IncludeUnsubscribed NullableBool `json:"include_unsubscribed,omitempty"`
 	// Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
 	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
@@ -4376,36 +4376,46 @@ func (o *Notification) UnsetDisableEmailClickTracking() {
 	o.DisableEmailClickTracking.Unset()
 }
 
-// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise.
+// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Notification) GetIncludeUnsubscribed() bool {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil || o.IncludeUnsubscribed.Get() == nil {
 		var ret bool
 		return ret
 	}
-	return *o.IncludeUnsubscribed
+	return *o.IncludeUnsubscribed.Get()
 }
 
 // GetIncludeUnsubscribedOk returns a tuple with the IncludeUnsubscribed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Notification) GetIncludeUnsubscribedOk() (*bool, bool) {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.IncludeUnsubscribed, true
+	return o.IncludeUnsubscribed.Get(), o.IncludeUnsubscribed.IsSet()
 }
 
 // HasIncludeUnsubscribed returns a boolean if a field has been set.
 func (o *Notification) HasIncludeUnsubscribed() bool {
-	if o != nil && o.IncludeUnsubscribed != nil {
+	if o != nil && o.IncludeUnsubscribed.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetIncludeUnsubscribed gets a reference to the given bool and assigns it to the IncludeUnsubscribed field.
+// SetIncludeUnsubscribed gets a reference to the given NullableBool and assigns it to the IncludeUnsubscribed field.
 func (o *Notification) SetIncludeUnsubscribed(v bool) {
-	o.IncludeUnsubscribed = &v
+	o.IncludeUnsubscribed.Set(&v)
+}
+// SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+func (o *Notification) SetIncludeUnsubscribedNil() {
+	o.IncludeUnsubscribed.Set(nil)
+}
+
+// UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
+func (o *Notification) UnsetIncludeUnsubscribed() {
+	o.IncludeUnsubscribed.Unset()
 }
 
 // GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -5193,8 +5203,8 @@ func (o Notification) MarshalJSON() ([]byte, error) {
 	if o.DisableEmailClickTracking.IsSet() {
 		toSerialize["disable_email_click_tracking"] = o.DisableEmailClickTracking.Get()
 	}
-	if o.IncludeUnsubscribed != nil {
-		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
+	if o.IncludeUnsubscribed.IsSet() {
+		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed.Get()
 	}
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc

--- a/model_notification_with_meta.go
+++ b/model_notification_with_meta.go
@@ -222,7 +222,7 @@ type NotificationWithMeta struct {
 	// Channel: Email Default is `false`. If set to `true`, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked.
 	DisableEmailClickTracking NullableBool `json:"disable_email_click_tracking,omitempty"`
 	// Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
-	IncludeUnsubscribed *bool `json:"include_unsubscribed,omitempty"`
+	IncludeUnsubscribed NullableBool `json:"include_unsubscribed,omitempty"`
 	// BCC recipients that were set on this email notification.
 	EmailBcc []string `json:"email_bcc,omitempty"`
 	// Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
@@ -4397,36 +4397,46 @@ func (o *NotificationWithMeta) UnsetDisableEmailClickTracking() {
 	o.DisableEmailClickTracking.Unset()
 }
 
-// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise.
+// GetIncludeUnsubscribed returns the IncludeUnsubscribed field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NotificationWithMeta) GetIncludeUnsubscribed() bool {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil || o.IncludeUnsubscribed.Get() == nil {
 		var ret bool
 		return ret
 	}
-	return *o.IncludeUnsubscribed
+	return *o.IncludeUnsubscribed.Get()
 }
 
 // GetIncludeUnsubscribedOk returns a tuple with the IncludeUnsubscribed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NotificationWithMeta) GetIncludeUnsubscribedOk() (*bool, bool) {
-	if o == nil || o.IncludeUnsubscribed == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.IncludeUnsubscribed, true
+	return o.IncludeUnsubscribed.Get(), o.IncludeUnsubscribed.IsSet()
 }
 
 // HasIncludeUnsubscribed returns a boolean if a field has been set.
 func (o *NotificationWithMeta) HasIncludeUnsubscribed() bool {
-	if o != nil && o.IncludeUnsubscribed != nil {
+	if o != nil && o.IncludeUnsubscribed.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetIncludeUnsubscribed gets a reference to the given bool and assigns it to the IncludeUnsubscribed field.
+// SetIncludeUnsubscribed gets a reference to the given NullableBool and assigns it to the IncludeUnsubscribed field.
 func (o *NotificationWithMeta) SetIncludeUnsubscribed(v bool) {
-	o.IncludeUnsubscribed = &v
+	o.IncludeUnsubscribed.Set(&v)
+}
+// SetIncludeUnsubscribedNil sets the value for IncludeUnsubscribed to be an explicit nil
+func (o *NotificationWithMeta) SetIncludeUnsubscribedNil() {
+	o.IncludeUnsubscribed.Set(nil)
+}
+
+// UnsetIncludeUnsubscribed ensures that no value is present for IncludeUnsubscribed, not even an explicit nil
+func (o *NotificationWithMeta) UnsetIncludeUnsubscribed() {
+	o.IncludeUnsubscribed.Unset()
 }
 
 // GetEmailBcc returns the EmailBcc field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -5628,8 +5638,8 @@ func (o NotificationWithMeta) MarshalJSON() ([]byte, error) {
 	if o.DisableEmailClickTracking.IsSet() {
 		toSerialize["disable_email_click_tracking"] = o.DisableEmailClickTracking.Get()
 	}
-	if o.IncludeUnsubscribed != nil {
-		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed
+	if o.IncludeUnsubscribed.IsSet() {
+		toSerialize["include_unsubscribed"] = o.IncludeUnsubscribed.Get()
 	}
 	if o.EmailBcc != nil {
 		toSerialize["email_bcc"] = o.EmailBcc


### PR DESCRIPTION
## Release v5.9.0

### 🐛 Bug Fixes
- fix: omit include_unsubscribed from requests when unset

### 📚 Docs
- docs: [SDK-4800] add AGENTS.md agent entry point to each SDK
- docs: [SDK-4800] fix AGENTS.md Rust import, retry base-delay, absolute README links
- docs: [SDK-4839] add realistic example values to user/segment/subscription schemas
- docs: [SDK-4842] standardize app-id placeholder, add headings to all push examples, note dateutil dependency
- docs: [SDK-4842] add example values for Purchase, Subscription id/carrier/web keys, and PropertiesObject.ip
- docs: [SDK-4842] add example values for Filter fields and IdentityObject entries
- docs: [SDK-4842] render valid Ruby in model doc examples and drop asymmetric identity sample

---
_Generated from [OneSignal/api-client-libraries@3d2dd1e...c6344eb](https://github.com/OneSignal/api-client-libraries/compare/3d2dd1e14ade327f44ed6d664aa9edeead221668...c6344eba29ae12a71c2b02c5cf6081ab38651ea4)._